### PR TITLE
Yocaml_irmin: Use Irmin Store as a compilation target

### DIFF
--- a/examples/06_first_blog_using_jingoo_and_git/articles/an_article.md
+++ b/examples/06_first_blog_using_jingoo_and_git/articles/an_article.md
@@ -1,0 +1,44 @@
+---
+date: 2021-05-22
+article_title: This is an example (updated)
+article_description: This is the description of the example
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin faucibus tortor
+justo, ac tempus nunc mollis ut. Suspendisse ex est, rutrum in nulla
+sollicitudin, elementum bibendum erat. Suspendisse id ante nec orci tempor
+vulputate nec a libero. Cras quam lectus, porttitor eu dolor nec, venenatis
+posuere arcu. Duis viverra velit purus, facilisis dictum odio mollis eget. In
+lacinia pretium erat, vel molestie ipsum elementum sit amet. Mauris varius
+lectus vel mauris malesuada volutpat. Duis non felis eros. Etiam ultrices
+pharetra eros nec rhoncus. Pellentesque habitant morbi tristique senectus et
+netus et malesuada fames ac turpis egestas. Nunc ac neque viverra, congue eros
+non, accumsan quam. Nulla in ornare odio. Vivamus et eros nulla.
+
+> Vestibulum porta orci elit, non feugiat tellus posuere id. Vestibulum bibendum
+> vel tellus non condimentum. Vestibulum risus arcu, dignissim vitae neque et,
+> cursus congue nisi. Nullam cursus varius dapibus. Donec justo lacus, consequat
+> in tempus et, sodales nec tortor. Nulla eget arcu eu metus hendrerit porttitor
+> nec vel purus. Morbi nec neque diam. Suspendisse sapien felis, rutrum eget
+> scelerisque quis, tempus id lacus. Pellentesque mattis lorem in purus iaculis
+> scelerisque eu sodales enim. Nulla consequat est ac magna tincidunt, quis
+> dignissim neque fermentum. Curabitur a mauris sit amet augue euismod pharetra.
+> Mauris non diam mattis, eleifend magna id, laoreet turpis. Cras hendrerit
+> magna eu nulla hendrerit, nec bibendum neque interdum. Mauris fringilla enim
+> quis dapibus sodales. Nam mattis egestas iaculis. Cras non sagittis justo.
+
+Curabitur aliquet bibendum dui id tincidunt. Proin in arcu lectus. Sed scelerisque tortor a nibh venenatis, sed rhoncus nisl lobortis. Etiam ut maximus elit, in pretium metus. Vestibulum vel urna a sem iaculis elementum sagittis et nisi. Praesent fermentum dolor mauris, placerat posuere nisi mattis sed. Fusce eu semper odio, tristique imperdiet tellus. Sed porttitor sem iaculis ex euismod, ac pulvinar dui finibus. Aenean ut bibendum dui. Proin finibus purus metus, finibus molestie nunc tristique eu. Cras laoreet, nisl id consequat pulvinar, odio erat placerat turpis, ac interdum tortor neque non metus. Pellentesque et turpis dictum, imperdiet ligula quis, posuere risus.
+
+> Phasellus et interdum nisi, eu placerat nisi. Morbi at volutpat ipsum, ac
+> lobortis erat. Maecenas venenatis est sed vestibulum pretium. Praesent egestas
+> urna risus, at feugiat diam euismod non. Morbi sit amet elementum nulla, quis
+> placerat dui. Nunc lacus velit, accumsan nec efficitur at, dictum eu sem.
+> Maecenas cursus nisl quis augue faucibus, eu dignissim neque rutrum. Nam in
+> finibus mauris, vitae vehicula quam. Nunc elementum mauris sed quam lacinia
+> auctor. Nullam malesuada, sapien ac tristique tempor, justo urna auctor orci,
+> vitae congue felis tortor vitae urna. Phasellus quis convallis nunc. Nunc sit
+> amet sagittis sapien, ut euismod orci. Vestibulum quis blandit sem, et
+> pulvinar enim. Pellentesque habitant morbi tristique senectus et netus et
+> malesuada fames ac turpis egestas.
+
+Sed suscipit purus sed nisi sodales tristique. Cras eu purus et metus mattis ornare eget sit amet erat. Aliquam eleifend, ante et pretium interdum, sem nisl porttitor magna, in molestie ligula nunc non est. Fusce eu sagittis ligula. Vivamus non sollicitudin leo, nec eleifend neque. Fusce malesuada mauris nisi, ac fringilla lectus molestie id. Suspendisse molestie massa sed rhoncus molestie. Etiam in leo nec ligula tristique scelerisque. Donec tincidunt nisl quam, non finibus sem vestibulum ut. Cras eu nibh est. Maecenas quis iaculis augue, fermentum finibus elit. Vivamus quis velit lorem. Aliquam finibus leo non lorem porttitor, sed finibus nulla interdum.

--- a/examples/06_first_blog_using_jingoo_and_git/articles/an_other_article.md
+++ b/examples/06_first_blog_using_jingoo_and_git/articles/an_other_article.md
@@ -1,0 +1,46 @@
+---
+date: 2021-05-23
+article_title: This is an other example (updated)
+article_description: This is the description of the other example
+---
+
+Test
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin faucibus tortor
+justo, ac tempus nunc mollis ut. Suspendisse ex est, rutrum in nulla
+sollicitudin, elementum bibendum erat. Suspendisse id ante nec orci tempor
+vulputate nec a libero. Cras quam lectus, porttitor eu dolor nec, venenatis
+posuere arcu. Duis viverra velit purus, facilisis dictum odio mollis eget. In
+lacinia pretium erat, vel molestie ipsum elementum sit amet. Mauris varius
+lectus vel mauris malesuada volutpat. Duis non felis eros. Etiam ultrices
+pharetra eros nec rhoncus. Pellentesque habitant morbi tristique senectus et
+netus et malesuada fames ac turpis egestas. Nunc ac neque viverra, congue eros
+non, accumsan quam. Nulla in ornare odio. Vivamus et eros nulla.
+
+> Vestibulum porta orci elit, non feugiat tellus posuere id. Vestibulum bibendum
+> vel tellus non condimentum. Vestibulum risus arcu, dignissim vitae neque et,
+> cursus congue nisi. Nullam cursus varius dapibus. Donec justo lacus, consequat
+> in tempus et, sodales nec tortor. Nulla eget arcu eu metus hendrerit porttitor
+> nec vel purus. Morbi nec neque diam. Suspendisse sapien felis, rutrum eget
+> scelerisque quis, tempus id lacus. Pellentesque mattis lorem in purus iaculis
+> scelerisque eu sodales enim. Nulla consequat est ac magna tincidunt, quis
+> dignissim neque fermentum. Curabitur a mauris sit amet augue euismod pharetra.
+> Mauris non diam mattis, eleifend magna id, laoreet turpis. Cras hendrerit
+> magna eu nulla hendrerit, nec bibendum neque interdum. Mauris fringilla enim
+> quis dapibus sodales. Nam mattis egestas iaculis. Cras non sagittis justo.
+
+Curabitur aliquet bibendum dui id tincidunt. Proin in arcu lectus. Sed scelerisque tortor a nibh venenatis, sed rhoncus nisl lobortis. Etiam ut maximus elit, in pretium metus. Vestibulum vel urna a sem iaculis elementum sagittis et nisi. Praesent fermentum dolor mauris, placerat posuere nisi mattis sed. Fusce eu semper odio, tristique imperdiet tellus. Sed porttitor sem iaculis ex euismod, ac pulvinar dui finibus. Aenean ut bibendum dui. Proin finibus purus metus, finibus molestie nunc tristique eu. Cras laoreet, nisl id consequat pulvinar, odio erat placerat turpis, ac interdum tortor neque non metus. Pellentesque et turpis dictum, imperdiet ligula quis, posuere risus.
+
+> Phasellus et interdum nisi, eu placerat nisi. Morbi at volutpat ipsum, ac
+> lobortis erat. Maecenas venenatis est sed vestibulum pretium. Praesent egestas
+> urna risus, at feugiat diam euismod non. Morbi sit amet elementum nulla, quis
+> placerat dui. Nunc lacus velit, accumsan nec efficitur at, dictum eu sem.
+> Maecenas cursus nisl quis augue faucibus, eu dignissim neque rutrum. Nam in
+> finibus mauris, vitae vehicula quam. Nunc elementum mauris sed quam lacinia
+> auctor. Nullam malesuada, sapien ac tristique tempor, justo urna auctor orci,
+> vitae congue felis tortor vitae urna. Phasellus quis convallis nunc. Nunc sit
+> amet sagittis sapien, ut euismod orci. Vestibulum quis blandit sem, et
+> pulvinar enim. Pellentesque habitant morbi tristique senectus et netus et
+> malesuada fames ac turpis egestas.
+
+Sed suscipit purus sed nisi sodales tristique. Cras eu purus et metus mattis ornare eget sit amet erat. Aliquam eleifend, ante et pretium interdum, sem nisl porttitor magna, in molestie ligula nunc non est. Fusce eu sagittis ligula. Vivamus non sollicitudin leo, nec eleifend neque. Fusce malesuada mauris nisi, ac fringilla lectus molestie id. Suspendisse molestie massa sed rhoncus molestie. Etiam in leo nec ligula tristique scelerisque. Donec tincidunt nisl quam, non finibus sem vestibulum ut. Cras eu nibh est. Maecenas quis iaculis augue, fermentum finibus elit. Vivamus quis velit lorem. Aliquam finibus leo non lorem porttitor, sed finibus nulla interdum.

--- a/examples/06_first_blog_using_jingoo_and_git/bin/dune
+++ b/examples/06_first_blog_using_jingoo_and_git/bin/dune
@@ -2,5 +2,12 @@
  (name my_site)
  (promote (until-clean))
  (libraries
-   yocaml yocaml_markdown yocaml_yaml yocaml_jingoo
-   yocaml_unix yocaml_irmin irmin-git))
+  yocaml
+  yocaml_markdown
+  yocaml_yaml
+  yocaml_jingoo
+  yocaml_unix
+  yocaml_irmin
+  irmin-git
+  irmin-unix
+  lwt.unix))

--- a/examples/06_first_blog_using_jingoo_and_git/bin/dune
+++ b/examples/06_first_blog_using_jingoo_and_git/bin/dune
@@ -1,0 +1,6 @@
+(executable
+ (name my_site)
+ (promote (until-clean))
+ (libraries
+   yocaml yocaml_markdown yocaml_yaml yocaml_jingoo
+   yocaml_unix yocaml_irmin irmin-git))

--- a/examples/06_first_blog_using_jingoo_and_git/bin/my_site.ml
+++ b/examples/06_first_blog_using_jingoo_and_git/bin/my_site.ml
@@ -100,6 +100,7 @@ let () =
   Yocaml_irmin.execute
     (module Yocaml_unix)
     (module Store)
+    (module Lwt_main)
     ~author:"xvw"
     ~author_email:"xaviervdw@gmail.com"
     config

--- a/examples/06_first_blog_using_jingoo_and_git/bin/my_site.ml
+++ b/examples/06_first_blog_using_jingoo_and_git/bin/my_site.ml
@@ -1,0 +1,107 @@
+open Yocaml
+module Store = Irmin_unix.Git.FS.KV (Irmin.Contents.String)
+
+let destination = "_build"
+let css_destination = "css"
+let images_destination = "images"
+let config = Irmin_git.config ~bare:true destination
+
+let may_process_markdown file =
+  let open Build in
+  if with_extension "md" file
+  then Yocaml_markdown.content_to_html ()
+  else arrow Fun.id
+;;
+
+let pages =
+  process_files
+    [ "pages/" ]
+    (fun f -> with_extension "html" f || with_extension "md" f)
+    (fun file ->
+      let fname = basename file in
+      let target = replace_extension fname "html" in
+      let open Build in
+      create_file
+        target
+        (Yocaml_yaml.read_file_with_metadata (module Metadata.Page) file
+        >>> may_process_markdown file
+        >>> Yocaml_jingoo.apply_as_template
+              (module Metadata.Page)
+              "templates/layout.html"
+        >>^ Stdlib.snd))
+;;
+
+let article_destination file =
+  let fname = basename file |> into "articles" in
+  replace_extension fname "html"
+;;
+
+let articles =
+  process_files [ "articles/" ] (with_extension "md") (fun file ->
+      let open Build in
+      let target = article_destination file in
+      create_file
+        target
+        (Yocaml_yaml.read_file_with_metadata (module Metadata.Article) file
+        >>> Yocaml_markdown.content_to_html ()
+        >>> Yocaml_jingoo.apply_as_template
+              (module Metadata.Article)
+              "templates/article.html"
+        >>> Yocaml_jingoo.apply_as_template
+              (module Metadata.Article)
+              "templates/layout.html"
+        >>^ Stdlib.snd))
+;;
+
+let css =
+  process_files [ "css/" ] (with_extension "css") (fun file ->
+      Build.copy_file file ~into:css_destination)
+;;
+
+let images =
+  let open Preface.Predicate in
+  process_files
+    [ "../04_first_blog/images" ]
+    (with_extension "svg" || with_extension "png" || with_extension "gif")
+    (fun file -> Build.copy_file file ~into:images_destination)
+;;
+
+let index =
+  let open Build in
+  let* articles =
+    collection
+      (read_child_files "articles/" (with_extension "md"))
+      (fun source ->
+        Yocaml_yaml.read_file_with_metadata (module Metadata.Article) source
+        >>^ fun (x, _) -> x, article_destination source)
+      (fun x meta content ->
+        x
+        |> Metadata.Articles.make
+             ?title:(Metadata.Page.title meta)
+             ?description:(Metadata.Page.description meta)
+        |> Metadata.Articles.sort_articles_by_date
+        |> fun x -> x, content)
+  in
+  create_file
+    "index.html"
+    (Yocaml_yaml.read_file_with_metadata (module Metadata.Page) "index.md"
+    >>> Yocaml_markdown.content_to_html ()
+    >>> articles
+    >>> Yocaml_jingoo.apply_as_template
+          (module Metadata.Articles)
+          "templates/list.html"
+    >>> Yocaml_jingoo.apply_as_template
+          (module Metadata.Articles)
+          "templates/layout.html"
+    >>^ Stdlib.snd)
+;;
+
+let () =
+  Yocaml_irmin.execute
+    (module Yocaml_unix)
+    (module Store)
+    ~author:"xvw"
+    ~author_email:"xaviervdw@gmail.com"
+    config
+    (pages >> css >> images >> articles >> index)
+;;

--- a/examples/06_first_blog_using_jingoo_and_git/bin/my_site.ml
+++ b/examples/06_first_blog_using_jingoo_and_git/bin/my_site.ml
@@ -74,7 +74,7 @@ let index =
       (fun source ->
         Yocaml_yaml.read_file_with_metadata (module Metadata.Article) source
         >>^ fun (x, _) -> x, article_destination source)
-      (fun x meta content ->
+      (fun x (meta, content) ->
         x
         |> Metadata.Articles.make
              ?title:(Metadata.Page.title meta)

--- a/examples/06_first_blog_using_jingoo_and_git/bin/my_site.ml
+++ b/examples/06_first_blog_using_jingoo_and_git/bin/my_site.ml
@@ -4,6 +4,7 @@ module Store = Irmin_unix.Git.FS.KV (Irmin.Contents.String)
 let destination = "_build"
 let css_destination = "css"
 let images_destination = "images"
+let track_binary_update = Build.watch Sys.argv.(0)
 let config = Irmin_git.config ~bare:true destination
 
 let may_process_markdown file =
@@ -23,7 +24,8 @@ let pages =
       let open Build in
       create_file
         target
-        (Yocaml_yaml.read_file_with_metadata (module Metadata.Page) file
+        (track_binary_update
+        >>> Yocaml_yaml.read_file_with_metadata (module Metadata.Page) file
         >>> may_process_markdown file
         >>> Yocaml_jingoo.apply_as_template
               (module Metadata.Page)
@@ -42,7 +44,8 @@ let articles =
       let target = article_destination file in
       create_file
         target
-        (Yocaml_yaml.read_file_with_metadata (module Metadata.Article) file
+        (track_binary_update
+        >>> Yocaml_yaml.read_file_with_metadata (module Metadata.Article) file
         >>> Yocaml_markdown.content_to_html ()
         >>> Yocaml_jingoo.apply_as_template
               (module Metadata.Article)
@@ -84,7 +87,8 @@ let index =
   in
   create_file
     "index.html"
-    (Yocaml_yaml.read_file_with_metadata (module Metadata.Page) "index.md"
+    (track_binary_update
+    >>> Yocaml_yaml.read_file_with_metadata (module Metadata.Page) "index.md"
     >>> Yocaml_markdown.content_to_html ()
     >>> articles
     >>> Yocaml_jingoo.apply_as_template

--- a/examples/06_first_blog_using_jingoo_and_git/index.md
+++ b/examples/06_first_blog_using_jingoo_and_git/index.md
@@ -1,0 +1,3 @@
+# Blog post
+
+> This is a blog stored into a git repository (using Irmin)

--- a/examples/06_first_blog_using_jingoo_and_git/index.md
+++ b/examples/06_first_blog_using_jingoo_and_git/index.md
@@ -1,3 +1,3 @@
-# Blog post
+# Blog post !
 
 > This is a blog stored into a git repository (using Irmin)

--- a/examples/06_first_blog_using_jingoo_and_git/pages/hello.md
+++ b/examples/06_first_blog_using_jingoo_and_git/pages/hello.md
@@ -1,0 +1,5 @@
+## Welcome to my website
+
+> I'm pretty proud of my website. YES!
+
+Hello World. (3)

--- a/examples/06_first_blog_using_jingoo_and_git/pages/hello.md
+++ b/examples/06_first_blog_using_jingoo_and_git/pages/hello.md
@@ -2,4 +2,4 @@
 
 > I'm pretty proud of my website. YES!
 
-Hello World. (3)
+Hello World !.

--- a/examples/06_first_blog_using_jingoo_and_git/templates/article.html
+++ b/examples/06_first_blog_using_jingoo_and_git/templates/article.html
@@ -1,0 +1,8 @@
+<a href="/index.html">Back to index</a>
+
+<article>
+    <h2>{{ article_title }}</h2>
+    {%- autoescape false -%}
+    {{ body }}
+    {% endautoescape -%}
+</article>

--- a/examples/06_first_blog_using_jingoo_and_git/templates/article.html
+++ b/examples/06_first_blog_using_jingoo_and_git/templates/article.html
@@ -1,5 +1,4 @@
 <a href="/index.html">Back to index</a>
-
 <article>
     <h2>{{ article_title }}</h2>
     {%- autoescape false -%}

--- a/examples/06_first_blog_using_jingoo_and_git/templates/layout.html
+++ b/examples/06_first_blog_using_jingoo_and_git/templates/layout.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>My website lol</title>
+        <title>My website using Git and Irmin</title>
     </head>
     <body>
         <h1>My blog!</h1>

--- a/examples/06_first_blog_using_jingoo_and_git/templates/layout.html
+++ b/examples/06_first_blog_using_jingoo_and_git/templates/layout.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>My website lol</title>
+    </head>
+    <body>
+        <h1>My blog!</h1>
+        <hr>
+        <main>
+            {%- autoescape false -%}
+            {{ body }}
+            {% endautoescape -%}
+        </main>
+        <hr>
+        copyright <strong>Myself</strong><br>
+        <img src="/images/ocaml.svg" style="width: 120px">
+    </body>
+</html>

--- a/examples/06_first_blog_using_jingoo_and_git/templates/list.html
+++ b/examples/06_first_blog_using_jingoo_and_git/templates/list.html
@@ -1,0 +1,15 @@
+{%- autoescape false -%}
+{{ body }}
+{% endautoescape -%}
+
+<h3>Blog</h3>
+
+<ol reversed class="list-articles">
+{% for article in articles %}
+<li>
+  <span class="date">{{ article.date.canonical  }}</span>
+  <a href="{{ article.url }}">{{ article.article_title }}</a><br />
+  <p>{{ article.article_description }}</p>
+</li>
+{% endfor %}
+</ol>

--- a/examples/06_first_blog_using_jingoo_and_git/templates/list.html
+++ b/examples/06_first_blog_using_jingoo_and_git/templates/list.html
@@ -3,7 +3,6 @@
 {% endautoescape -%}
 
 <h3>Blog</h3>
-
 <ol reversed class="list-articles">
 {% for article in articles %}
 <li>

--- a/lib/yocaml/deps.ml
+++ b/lib/yocaml/deps.ml
@@ -61,11 +61,11 @@ let nel_for_one f =
 let need_update deps target =
   let open Preface.Fun.Infix in
   let open Effect.Monad in
-  Effect.file_exists target
+  Effect.target_exists target
   >>= function
   | false -> return $ Try.ok true
   | true ->
-    Effect.get_modification_time target
+    Effect.target_modification_time target
     >>= (function
     | Error err -> return $ Try.error err
     | Ok mtime ->

--- a/lib/yocaml/deps.ml
+++ b/lib/yocaml/deps.ml
@@ -49,11 +49,16 @@ let get_max_modification_time deps =
         % Nonempty_list_try.sequence
 ;;
 
+let bool_to_action = function
+  | true -> `Need_update
+  | false -> `Up_to_date
+;;
+
 let nel_for_one f =
   let open Preface.Nonempty_list in
   let rec loop = function
-    | Last x -> f x
-    | x :: xs -> if f x then true else loop xs
+    | Last x -> bool_to_action $ f x
+    | x :: xs -> if f x then `Need_update else loop xs
   in
   loop
 ;;
@@ -63,14 +68,14 @@ let need_update deps target =
   let open Effect.Monad in
   Effect.target_exists target
   >>= function
-  | false -> return $ Try.ok true
+  | false -> return $ Try.ok `Need_creation
   | true ->
     Effect.target_modification_time target
     >>= (function
     | Error err -> return $ Try.error err
     | Ok mtime ->
       (match deps |> to_list |> Preface.Nonempty_list.from_list with
-      | None -> return $ Try.ok false
+      | None -> return $ Try.ok `Up_to_date
       | Some deps_list ->
         Nonempty_list_effects.traverse get_modification_time deps_list
         >|= Try.Functor.map (nel_for_one (fun x -> x >= mtime))

--- a/lib/yocaml/deps.mli
+++ b/lib/yocaml/deps.mli
@@ -40,7 +40,10 @@ val get_max_modification_time : t -> int option Try.t Effect.t
 
 (** Defines whether a {!type:Aliases.Filepath.t} should be updated according
     to a {!type:t} using the effects management logic.*)
-val need_update : t -> Filepath.t -> bool Try.t Effect.t
+val need_update
+  :  t
+  -> Filepath.t
+  -> [ `Need_creation | `Need_update | `Up_to_date ] Try.t Effect.t
 
 (** {1 Implementations} *)
 

--- a/lib/yocaml/effect.ml
+++ b/lib/yocaml/effect.ml
@@ -28,16 +28,16 @@ type (_, 'a) effects =
 
 module Freer = Preface.Make.Freer_monad.Over (struct
   type 'a t =
-    ( < file_exists : e
-      ; target_exists : e
-      ; get_modification_time : e
-      ; target_modification_time : e
-      ; read_file : e
-      ; write_file : e
-      ; read_dir : e
-      ; log : e
-      ; throw : e
-      ; raise_ : e >
+    ( < file_exists : unit
+      ; target_exists : unit
+      ; get_modification_time : unit
+      ; target_modification_time : unit
+      ; read_file : unit
+      ; write_file : unit
+      ; read_dir : unit
+      ; log : unit
+      ; throw : unit
+      ; raise_ : unit >
     , 'a )
     effects
 end)

--- a/lib/yocaml/effect.ml
+++ b/lib/yocaml/effect.ml
@@ -2,9 +2,15 @@ open Util
 
 type (_, 'a) effects =
   | File_exists : Filepath.t -> (< file_exists : unit ; .. >, bool) effects
+  | Target_exists :
+      Filepath.t
+      -> (< target_exists : unit ; .. >, bool) effects
   | Get_modification_time :
       Filepath.t
       -> (< get_modification_time : unit ; .. >, int Try.t) effects
+  | Target_modification_time :
+      Filepath.t
+      -> (< target_modification_time : unit ; .. >, int Try.t) effects
   | Read_file :
       Filepath.t
       -> (< read_file : unit ; .. >, string Try.t) effects
@@ -22,20 +28,28 @@ type (_, 'a) effects =
 
 module Freer = Preface.Make.Freer_monad.Over (struct
   type 'a t =
-    ( < file_exists : unit
-      ; get_modification_time : unit
-      ; read_file : unit
-      ; write_file : unit
-      ; read_dir : unit
-      ; log : unit
-      ; throw : unit
-      ; raise_ : unit >
+    ( < file_exists : e
+      ; target_exists : e
+      ; get_modification_time : e
+      ; target_modification_time : e
+      ; read_file : e
+      ; write_file : e
+      ; read_dir : e
+      ; log : e
+      ; throw : e
+      ; raise_ : e >
     , 'a )
     effects
 end)
 
 let file_exists path = Freer.perform $ File_exists path
+let target_exists path = Freer.perform $ Target_exists path
 let get_modification_time path = Freer.perform $ Get_modification_time path
+
+let target_modification_time path =
+  Freer.perform $ Target_modification_time path
+;;
+
 let read_file path = Freer.perform $ Read_file path
 let write_file path content = Freer.perform $ Write_file (path, content)
 let log level message = Freer.perform $ Log (level, message)

--- a/lib/yocaml/effect.ml
+++ b/lib/yocaml/effect.ml
@@ -14,6 +14,11 @@ type (_, 'a) effects =
   | Read_file :
       Filepath.t
       -> (< read_file : unit ; .. >, string Try.t) effects
+  | Content_changes :
+      (Filepath.t * string)
+      -> ( < content_changes : unit ; .. >
+         , (string, unit) Either.t Try.t )
+         effects
   | Write_file :
       (Filepath.t * string)
       -> (< write_file : unit ; .. >, unit Try.t) effects
@@ -34,6 +39,7 @@ module Freer = Preface.Make.Freer_monad.Over (struct
       ; target_modification_time : unit
       ; read_file : unit
       ; write_file : unit
+      ; content_changes : unit
       ; read_dir : unit
       ; log : unit
       ; throw : unit
@@ -51,6 +57,11 @@ let target_modification_time path =
 ;;
 
 let read_file path = Freer.perform $ Read_file path
+
+let content_changes file content =
+  Freer.perform $ Content_changes (file, content)
+;;
+
 let write_file path content = Freer.perform $ Write_file (path, content)
 let log level message = Freer.perform $ Log (level, message)
 let trace = log Trace

--- a/lib/yocaml/effect.mli
+++ b/lib/yocaml/effect.mli
@@ -22,9 +22,15 @@
 
 type (_, 'a) effects =
   | File_exists : Filepath.t -> (< file_exists : unit ; .. >, bool) effects
+  | Target_exists :
+      Filepath.t
+      -> (< target_exists : unit ; .. >, bool) effects
   | Get_modification_time :
       Filepath.t
       -> (< get_modification_time : unit ; .. >, int Try.t) effects
+  | Target_modification_time :
+      Filepath.t
+      -> (< target_modification_time : unit ; .. >, int Try.t) effects
   | Read_file :
       Filepath.t
       -> (< read_file : unit ; .. >, string Try.t) effects
@@ -59,7 +65,9 @@ module Freer :
   Preface_specs.FREER_MONAD
     with type 'a f =
           ( < file_exists : unit
+            ; target_exists : unit
             ; get_modification_time : unit
+            ; target_modification_time : unit
             ; read_file : unit
             ; write_file : unit
             ; read_dir : unit
@@ -85,10 +93,19 @@ module Freer :
     denoted by the file path [path] exists, [false] otherwise. *)
 val file_exists : Filepath.t -> bool Freer.t
 
+(** [target_exists path] should be interpreted as returning [true] if the file
+    denoted by the file path [path] exists, [false] otherwise. *)
+val target_exists : filepath -> bool Freer.t
+
 (** [get_modification_time path] should be interpreted as returning, as an
     integer, the Unix time ([mtime] corresponding to the modification date of
     the file denoted by the file path [path]. *)
 val get_modification_time : Filepath.t -> int Try.t Freer.t
+
+(** [target_modification_time path] should be interpreted as returning, as an
+    integer, the Unix time ([mtime] corresponding to the modification date of
+    the file denoted by the file path [path]. *)
+val target_modification_time : filepath -> int Try.t Freer.t
 
 (** [read_file path] should be interpreted as trying to read the contents of
     the file denoted by the file path [path]. At the moment I'm using strings

--- a/lib/yocaml/effect.mli
+++ b/lib/yocaml/effect.mli
@@ -95,7 +95,7 @@ val file_exists : Filepath.t -> bool Freer.t
 
 (** [target_exists path] should be interpreted as returning [true] if the file
     denoted by the file path [path] exists, [false] otherwise. *)
-val target_exists : filepath -> bool Freer.t
+val target_exists : Filepath.t -> bool Freer.t
 
 (** [get_modification_time path] should be interpreted as returning, as an
     integer, the Unix time ([mtime] corresponding to the modification date of
@@ -105,7 +105,7 @@ val get_modification_time : Filepath.t -> int Try.t Freer.t
 (** [target_modification_time path] should be interpreted as returning, as an
     integer, the Unix time ([mtime] corresponding to the modification date of
     the file denoted by the file path [path]. *)
-val target_modification_time : filepath -> int Try.t Freer.t
+val target_modification_time : Filepath.t -> int Try.t Freer.t
 
 (** [read_file path] should be interpreted as trying to read the contents of
     the file denoted by the file path [path]. At the moment I'm using strings

--- a/lib/yocaml/effect.mli
+++ b/lib/yocaml/effect.mli
@@ -34,6 +34,11 @@ type (_, 'a) effects =
   | Read_file :
       Filepath.t
       -> (< read_file : unit ; .. >, string Try.t) effects
+  | Content_changes :
+      (string * Filepath.t)
+      -> ( < content_changes : unit ; .. >
+         , (string, unit) Either.t Try.t )
+         effects
   | Write_file :
       (Filepath.t * string)
       -> (< write_file : unit ; .. >, unit Try.t) effects
@@ -70,6 +75,7 @@ module Freer :
             ; target_modification_time : unit
             ; read_file : unit
             ; write_file : unit
+            ; content_changes : unit
             ; read_dir : unit
             ; log : unit
             ; throw : unit
@@ -112,6 +118,14 @@ val target_modification_time : Filepath.t -> int Try.t Freer.t
     mainly out of laziness, and as I'll probably be the only user of this
     library... it doesn't matter! *)
 val read_file : Filepath.t -> string Try.t Freer.t
+
+(** [content_changes content filepath] should be interpreted as trying to
+    check if the content of the file is different from the given content. (In
+    order to reduce the mtime modification) *)
+val content_changes
+  :  Filepath.t
+  -> string
+  -> (string, unit) Either.t Try.t Freer.t
 
 (** [write_file path content] should be interpreted as trying to write
     [content] to the file denoted by the file path [path]. In my understanding

--- a/lib/yocaml/error.ml
+++ b/lib/yocaml/error.ml
@@ -15,6 +15,7 @@ type t =
   | Invalid_month of int
   | Invalid_range of int * int * int
   | Unknown of string
+  | Message of string
 
 exception Error of t
 
@@ -22,6 +23,7 @@ let rec pp formater error =
   let ppf x = Format.fprintf formater x in
   match error with
   | Unknown message -> ppf "Unknown (%s)" message
+  | Message message -> ppf "%s" message
   | Unix (error, fname, arg) -> ppf "Unix (%s, %s, %s)" error fname arg
   | Unreadable_file filename -> ppf "Unreadable_file (%s)" filename
   | Missing_field field -> ppf "Missing_field (%s)" field
@@ -56,6 +58,7 @@ let raise' error = raise (to_exn error)
 
 let rec equal x y =
   match x, y with
+  | Message a, Message b -> String.equal a b
   | Unknown a, Unknown b -> String.equal a b
   | Unix (a, b, c), Unix (x, y, z) ->
     a = x && String.equal b y && String.equal c z

--- a/lib/yocaml/error.mli
+++ b/lib/yocaml/error.mli
@@ -27,6 +27,7 @@ type t =
   | Invalid_month of int
   | Invalid_range of int * int * int
   | Unknown of string (** An unq\ualified error (probably due to laziness). *)
+  | Message of string
 
 (** Represents an [Error.t] in [exception]. *)
 exception Error of t

--- a/lib/yocaml/index.mld
+++ b/lib/yocaml/index.mld
@@ -47,6 +47,8 @@ context. This separation allows to have a pure and platform agnostic kernel (the
 only a UNIX runtime.
 
 - {{:../yocaml_unix/index.html} Yocaml_unix} An UNIX Runtime for YOCaml
+- {{:../yocaml_irmin/index.html} Yocaml_irmin} Uses {{:https://irmin.org} Irmin}
+  as a compilation target
 
 {2 Plugins}
 

--- a/lib/yocaml/lexicon.ml
+++ b/lib/yocaml/lexicon.ml
@@ -9,3 +9,4 @@ let oh_dear_there_is_an_error x =
 let crap_there_is_an_error = oh_dear_there_is_an_error Error.pp
 let crap_there_is_an_exception = oh_dear_there_is_an_error Preface.Exn.pp
 let target_need_to_be_built = Format.asprintf "Fresh: %s"
+let target_need_to_be_read = Format.asprintf "Read: %s"

--- a/lib/yocaml/lexicon.mli
+++ b/lib/yocaml/lexicon.mli
@@ -17,6 +17,9 @@ type t = string
 (** Occurs when a target need to be built. *)
 val target_need_to_be_built : Filepath.t -> t
 
+(** Occurs when a target need to be read. *)
+val target_need_to_be_read : Filepath.t -> t
+
 (** Occurs when a target is up to date. *)
 val target_is_up_to_date : Filepath.t -> t
 

--- a/lib/yocaml/runtime.ml
+++ b/lib/yocaml/runtime.ml
@@ -2,8 +2,10 @@ open Util
 
 module type RUNTIME = sig
   val file_exists : Filepath.t -> bool
+  val target_exists : Filepath.t -> bool
   val is_directory : Filepath.t -> bool
   val get_modification_time : Filepath.t -> int Try.t
+  val target_exists : Filepath.t -> bool
   val read_file : Filepath.t -> string Try.t
   val write_file : Filepath.t -> string -> unit Try.t
   val read_dir : Filepath.t -> Filepath.t list
@@ -38,7 +40,10 @@ let execute (module R : RUNTIME) program =
            fun resume -> function
             | Effect.Get_modification_time path ->
               resume $ R.get_modification_time path
+            | Effect.Target_modification_time path ->
+              resume $ R.target_modification_time path
             | Effect.File_exists path -> resume $ R.file_exists path
+            | Effect.Target_exists path -> resume $ R.target_exists path
             | Effect.Read_file path -> resume $ R.read_file path
             | Effect.Write_file (path, content) ->
               let () = R.create_dir $ Filename.dirname path in

--- a/lib/yocaml/runtime.ml
+++ b/lib/yocaml/runtime.ml
@@ -1,11 +1,12 @@
 open Util
 
 module type RUNTIME = sig
+  val get_time : unit -> float
   val file_exists : Filepath.t -> bool
   val target_exists : Filepath.t -> bool
   val is_directory : Filepath.t -> bool
   val get_modification_time : Filepath.t -> int Try.t
-  val target_exists : Filepath.t -> bool
+  val target_modification_time : Filepath.t -> int Try.t
   val read_file : Filepath.t -> string Try.t
   val write_file : Filepath.t -> string -> unit Try.t
   val read_dir : Filepath.t -> Filepath.t list

--- a/lib/yocaml/runtime.ml
+++ b/lib/yocaml/runtime.ml
@@ -8,6 +8,7 @@ module type RUNTIME = sig
   val get_modification_time : Filepath.t -> int Try.t
   val target_modification_time : Filepath.t -> int Try.t
   val read_file : Filepath.t -> string Try.t
+  val content_changes : Filepath.t -> string -> bool Try.t
   val write_file : Filepath.t -> string -> unit Try.t
   val read_dir : Filepath.t -> Filepath.t list
   val create_dir : ?file_perm:int -> Filepath.t -> unit
@@ -46,6 +47,14 @@ let execute (module R : RUNTIME) program =
             | Effect.File_exists path -> resume $ R.file_exists path
             | Effect.Target_exists path -> resume $ R.target_exists path
             | Effect.Read_file path -> resume $ R.read_file path
+            | Effect.Content_changes (path, content) ->
+              let result =
+                R.content_changes path content
+                |> Try.Functor.map (function
+                       | true -> Either.left content
+                       | false -> Either.right ())
+              in
+              resume result
             | Effect.Write_file (path, content) ->
               let () = R.create_dir $ Filename.dirname path in
               resume $ R.write_file path content

--- a/lib/yocaml/runtime.mli
+++ b/lib/yocaml/runtime.mli
@@ -21,6 +21,9 @@ module type RUNTIME = sig
       a directory), [false] otherwise. *)
   val file_exists : Filepath.t -> bool
 
+  (** Same of [file_exists] but acting on the target. *)
+  val target_exists : filepath -> bool
+
   (** [is_directory path] should returns [true] if [path] is an existing file
       and if the file is a directory, [false] otherwise. *)
   val is_directory : Filepath.t -> bool
@@ -29,6 +32,9 @@ module type RUNTIME = sig
       modification time (as an integer) of the given file. The function may
       fail. *)
   val get_modification_time : Filepath.t -> int Try.t
+
+  (** Same of [get_modification_time] but acting on the target. *)
+  val target_modification_time : filepath -> int Try.t
 
   (** [read_file path] should returns a [Try.t] containing the content (as a
       string) of the given file. The function may fail.*)

--- a/lib/yocaml/runtime.mli
+++ b/lib/yocaml/runtime.mli
@@ -25,7 +25,7 @@ module type RUNTIME = sig
   val file_exists : Filepath.t -> bool
 
   (** Same of [file_exists] but acting on the target. *)
-  val target_exists : filepath -> bool
+  val target_exists : Filepath.t -> bool
 
   (** [is_directory path] should returns [true] if [path] is an existing file
       and if the file is a directory, [false] otherwise. *)
@@ -37,7 +37,7 @@ module type RUNTIME = sig
   val get_modification_time : Filepath.t -> int Try.t
 
   (** Same of [get_modification_time] but acting on the target. *)
-  val target_modification_time : filepath -> int Try.t
+  val target_modification_time : Filepath.t -> int Try.t
 
   (** [read_file path] should returns a [Try.t] containing the content (as a
       string) of the given file. The function may fail.*)

--- a/lib/yocaml/runtime.mli
+++ b/lib/yocaml/runtime.mli
@@ -17,6 +17,9 @@
     an additional runtime. *)
 
 module type RUNTIME = sig
+  (** [get_time ()] should returns a float like [Unix.gettimeofday ()]. *)
+  val get_time : unit -> float
+
   (** [file_exists path] should returns [true] if [path] exists (as a file or
       a directory), [false] otherwise. *)
   val file_exists : Filepath.t -> bool

--- a/lib/yocaml/runtime.mli
+++ b/lib/yocaml/runtime.mli
@@ -43,6 +43,10 @@ module type RUNTIME = sig
       string) of the given file. The function may fail.*)
   val read_file : Filepath.t -> string Try.t
 
+  (** [content_changes filepath new_content] check if the content of the file
+      has been changed. *)
+  val content_changes : Filepath.t -> string -> bool Try.t
+
   (** [write_file path content] should write (create or overwrite) [content]
       into the given path. The function may fail. *)
   val write_file : Filepath.t -> string -> unit Try.t

--- a/lib/yocaml/validate.ml
+++ b/lib/yocaml/validate.ml
@@ -26,16 +26,4 @@ module Functor = Preface.Validation.Functor (Error_list)
 module Applicative = Preface.Validation.Applicative (Error_list)
 module Selective = Preface.Validation.Selective (Error_list)
 module Monad = Preface.Validation.Monad (Error_list)
-
-module Alt =
-  Preface.Make.Alt.Over_functor
-    (Functor)
-    (struct
-      type nonrec 'a t = 'a t
-
-      let combine a b =
-        match a, b with
-        | Preface.Validation.Invalid _, result -> result
-        | Preface.Validation.Valid x, _ -> Preface.Validation.Valid x
-      ;;
-    end)
+module Alt = Preface.Validation.Alt (Error_list)

--- a/lib/yocaml_irmin/dune
+++ b/lib/yocaml_irmin/dune
@@ -1,7 +1,7 @@
 (library
  (name yocaml_irmin)
  (public_name yocaml_irmin)
- (libraries lwt lwt.unix irmin irmin-unix preface yocaml))
+ (libraries lwt irmin preface yocaml))
 
 (documentation
  (package yocaml_irmin))

--- a/lib/yocaml_irmin/dune
+++ b/lib/yocaml_irmin/dune
@@ -1,0 +1,7 @@
+(library
+ (name yocaml_irmin)
+ (public_name yocaml_irmin)
+ (libraries lwt lwt.unix irmin irmin-unix preface yocaml))
+
+(documentation
+ (package yocaml_irmin))

--- a/lib/yocaml_irmin/runtime.ml
+++ b/lib/yocaml_irmin/runtime.ml
@@ -1,0 +1,96 @@
+open Yocaml
+
+module type CONFIG = sig
+  val config : Irmin.config
+  val branch : string
+  val author : string option
+  val author_email : string option
+end
+
+let set_error = function
+  | Ok x -> Try.ok x
+  | Error (`Conflict conflict) ->
+    Error.to_try $ Message ("Conflict: " ^ conflict)
+  | Error (`Too_many_retries n) ->
+    Error.to_try $ Message (Format.asprintf "Too many retiries %d" n)
+  | Error (`Test_was _) -> Error.to_try $ Message "Test_was"
+;;
+
+let path_of = String.split_on_char '/'
+
+module Make
+    (Source : Yocaml.Runtime.RUNTIME)
+    (Store : Irmin.S
+               with type branch = string
+                and type key = string list
+                and type contents = string)
+    (Config : CONFIG) =
+struct
+  let commit_author =
+    let user = Option.value ~default:"yocaml" Config.author
+    and mail = Option.value ~default:"admin@yocaml.io" Config.author_email in
+    Format.asprintf "%s <%s>" user mail
+  ;;
+
+  let branch =
+    let open Lwt.Syntax in
+    let* repo = Store.Repo.v Config.config in
+    Store.of_branch repo Config.branch
+  ;;
+
+  let create_dir ?(file_perm = 0) _ =
+    (* Path are Keys in Irmin so [create_dir] is useless*)
+    let _ = file_perm in
+    (* Trick for avoiding warning on unused variable  *)
+    ()
+  ;;
+
+  let target_exists filepath =
+    let path = path_of filepath in
+    let task =
+      let open Lwt.Syntax in
+      let* active_branch = branch in
+      Store.mem active_branch path
+    in
+    Lwt_main.run task
+  ;;
+
+  let write_file filepath content =
+    let info =
+      Irmin_unix.info ~author:commit_author "create file [%s]" filepath
+    in
+    let path = path_of filepath in
+    let task =
+      let open Lwt.Syntax in
+      let* active_branch = branch in
+      let+ result = Store.set ~info active_branch path content in
+      set_error result
+    in
+    Lwt_main.run task
+  ;;
+
+  let target_modification_time filepath =
+    let path = path_of filepath in
+    let task =
+      let open Lwt.Syntax in
+      let* active_branch = branch in
+      let+ commits = Store.last_modified ~n:1 active_branch path in
+      match List.rev commits with
+      | [] -> Ok 0
+      | commit :: _ ->
+        let info = Store.Commit.info commit in
+        let date = Irmin.Info.date info in
+        Ok (Int64.to_int date)
+    in
+    Lwt_main.run task
+  ;;
+
+  (* Additional Runtime for dealing with a Source. *)
+
+  let file_exists = Source.file_exists
+  let is_directory = Source.is_directory
+  let get_modification_time = Source.get_modification_time
+  let read_file = Source.read_file
+  let read_dir = Source.read_dir
+  let log = Source.log
+end

--- a/lib/yocaml_irmin/runtime.mli
+++ b/lib/yocaml_irmin/runtime.mli
@@ -1,0 +1,14 @@
+module type CONFIG = sig
+  val config : Irmin.config
+  val branch : string
+  val author : string option
+  val author_email : string option
+end
+
+module Make
+    (Source : Yocaml.Runtime.RUNTIME)
+    (Store : Irmin.S
+               with type branch = string
+                and type key = string list
+                and type contents = string)
+    (Config : CONFIG) : Yocaml.Runtime.RUNTIME

--- a/lib/yocaml_irmin/runtime.mli
+++ b/lib/yocaml_irmin/runtime.mli
@@ -5,10 +5,15 @@ module type CONFIG = sig
   val author_email : string option
 end
 
+module type LWT_RUN = sig
+  val run : 'a Lwt.t -> 'a
+end
+
 module Make
     (Source : Yocaml.Runtime.RUNTIME)
     (Store : Irmin.S
                with type branch = string
                 and type key = string list
                 and type contents = string)
+    (Lwt_main : LWT_RUN)
     (Config : CONFIG) : Yocaml.Runtime.RUNTIME

--- a/lib/yocaml_irmin/yocaml_irmin.ml
+++ b/lib/yocaml_irmin/yocaml_irmin.ml
@@ -1,0 +1,23 @@
+let execute
+    (module Source : Yocaml.Runtime.RUNTIME)
+    (module Store : Irmin.S
+      with type branch = string
+       and type key = string list
+       and type contents = string)
+    ?branch
+    ?author
+    ?author_email
+    config
+    program
+  =
+  let module R =
+    Runtime.Make (Source) (Store)
+      (struct
+        let config = config
+        let branch = Option.value ~default:"master" branch
+        let author = author
+        let author_email = author_email
+      end)
+  in
+  Yocaml.Runtime.execute (module R) program
+;;

--- a/lib/yocaml_irmin/yocaml_irmin.ml
+++ b/lib/yocaml_irmin/yocaml_irmin.ml
@@ -4,6 +4,7 @@ let execute
       with type branch = string
        and type key = string list
        and type contents = string)
+    (module Lwt_main : Runtime.LWT_RUN)
     ?branch
     ?author
     ?author_email
@@ -11,7 +12,7 @@ let execute
     program
   =
   let module R =
-    Runtime.Make (Source) (Store)
+    Runtime.Make (Source) (Store) (Lwt_main)
       (struct
         let config = config
         let branch = Option.value ~default:"master" branch

--- a/lib/yocaml_irmin/yocaml_irmin.mli
+++ b/lib/yocaml_irmin/yocaml_irmin.mli
@@ -1,0 +1,19 @@
+(** Allows you to define a Runtime that uses an Irmin [Store] (e.g. Git) as a
+    compilation target. *)
+
+(** {1 API} *)
+
+(** Executes a YOCaml program using a given Runtime for processing with
+    [Source] and using an [Irmin Store] as compilation target. *)
+val execute
+  :  (module Yocaml.Runtime.RUNTIME)
+  -> (module Irmin.S
+        with type branch = string
+         and type key = string list
+         and type contents = string)
+  -> ?branch:string
+  -> ?author:string
+  -> ?author_email:string
+  -> Irmin.config
+  -> 'a Yocaml.Effect.t
+  -> 'a

--- a/lib/yocaml_irmin/yocaml_irmin.mli
+++ b/lib/yocaml_irmin/yocaml_irmin.mli
@@ -11,6 +11,7 @@ val execute
         with type branch = string
          and type key = string list
          and type contents = string)
+  -> (module Runtime.LWT_RUN)
   -> ?branch:string
   -> ?author:string
   -> ?author_email:string

--- a/lib/yocaml_unix/dune
+++ b/lib/yocaml_unix/dune
@@ -1,7 +1,7 @@
 (library
  (name yocaml_unix)
  (public_name yocaml_unix)
- (libraries unix yocaml))
+ (libraries cryptokit unix yocaml))
 
 (documentation
  (package yocaml_unix))

--- a/lib/yocaml_unix/runtime.ml
+++ b/lib/yocaml_unix/runtime.ml
@@ -1,5 +1,6 @@
 open Yocaml.Util
 
+let get_time () = Unix.gettimeofday ()
 let file_exists = Sys.file_exists
 let is_directory = Sys.is_directory
 let target_exists = file_exists

--- a/lib/yocaml_unix/runtime.ml
+++ b/lib/yocaml_unix/runtime.ml
@@ -2,6 +2,7 @@ open Yocaml.Util
 
 let file_exists = Sys.file_exists
 let is_directory = Sys.is_directory
+let target_exists = file_exists
 
 let get_modification_time path =
   let open Unix in
@@ -12,6 +13,8 @@ let get_modification_time path =
   | Unix_error (err, f, p) ->
     Yocaml.Error.(to_try (Unix (Unix.error_message err, f, p)))
 ;;
+
+let target_modification_time = get_modification_time
 
 let bytes_of_in_channel channel =
   let length = in_channel_length channel in

--- a/lib/yocaml_unix/runtime.ml
+++ b/lib/yocaml_unix/runtime.ml
@@ -110,3 +110,16 @@ let read_dir path =
   try Sys.readdir path |> Array.to_list with
   | _ -> []
 ;;
+
+let hash value =
+  let open Cryptokit in
+  value |> hash_string (Hash.sha256 ()) |> transform_string (Hexa.encode ())
+;;
+
+let content_changes path new_content =
+  let open Yocaml.Try.Monad in
+  let+ old_content = read_file path in
+  let new_content_checksum = hash new_content
+  and old_content_checksum = hash old_content in
+  not (String.equal new_content_checksum old_content_checksum)
+;;

--- a/lib/yocaml_unix/yocaml_unix.ml
+++ b/lib/yocaml_unix/yocaml_unix.ml
@@ -1,1 +1,3 @@
 let execute program = Yocaml.Runtime.execute (module Runtime) program
+
+include Runtime

--- a/lib/yocaml_unix/yocaml_unix.mli
+++ b/lib/yocaml_unix/yocaml_unix.mli
@@ -5,5 +5,12 @@
 
 (** {1 API} *)
 
-(** Executes an YOCaml program using the UNIX Runtime. *)
+(** Executes a YOCaml program using the UNIX Runtime. *)
 val execute : 'a Yocaml.Effect.t -> 'a
+
+(** {1 Runtime}
+
+    Inclusion of the runtime to be able to use [Yocaml_unix] as runtime
+    directly. *)
+
+include Yocaml.Runtime.RUNTIME (** @closed *)

--- a/tests/deps_test.ml
+++ b/tests/deps_test.ml
@@ -1,5 +1,25 @@
 open Yocaml
 
+let pp_act ppf s =
+  Format.fprintf
+    ppf
+    "%s"
+    (match s with
+    | `Need_creation -> "`Need_creation"
+    | `Need_update -> "`Need_update"
+    | `Up_to_date -> "`Up_to_date")
+;;
+
+let eq_act a b =
+  match a, b with
+  | `Need_update, `Need_update
+  | `Need_creation, `Need_creation
+  | `Up_to_date, `Up_to_date -> true
+  | _ -> false
+;;
+
+let testable_act = Alcotest.testable pp_act eq_act
+
 let need_update_no_deps_file_not_present =
   let open Alcotest in
   test_case "When the file has no dependencies but does not exists" `Quick
@@ -7,10 +27,10 @@ let need_update_no_deps_file_not_present =
   let dummy = Dummy.make () in
   let deps = Deps.empty in
   let target = "my-file.txt" in
-  let expected = Try.ok true in
+  let expected = Try.ok `Need_creation in
   let computed = Dummy.handle dummy $ Deps.need_update deps target in
   check
-    (result bool (testable Error.pp Error.equal))
+    (result testable_act (testable Error.pp Error.equal))
     "since the filesystem is empty, the file need to be updated"
     expected
     computed
@@ -28,10 +48,10 @@ let need_update_no_deps_file_present =
   in
   let deps = Deps.empty in
   let target = "my-file.txt" in
-  let expected = Try.ok false in
+  let expected = Try.ok `Up_to_date in
   let computed = Dummy.handle dummy $ Deps.need_update deps target in
   check
-    (result bool (testable Error.pp Error.equal))
+    (result testable_act (testable Error.pp Error.equal))
     "The target has no dependencies and exists in the file system, so it \
      does not need to be updated"
     expected
@@ -57,10 +77,10 @@ let need_update_updated_deps_file_present =
     Deps.(of_list [ file "deps1.html"; file "deps2.html"; file "deps3.html" ])
   in
   let target = "my-file.txt" in
-  let expected = Try.ok false in
+  let expected = Try.ok `Up_to_date in
   let computed = Dummy.handle dummy $ Deps.need_update deps target in
   check
-    (result bool (testable Error.pp Error.equal))
+    (result testable_act (testable Error.pp Error.equal))
     "The target has dependencies but they are all up to date, so it should \
      not be updated"
     expected
@@ -86,10 +106,10 @@ let need_update_outatded_deps_file_present =
     Deps.(of_list [ file "deps1.html"; file "deps2.html"; file "deps3.html" ])
   in
   let target = "my-file.txt" in
-  let expected = Try.ok true in
+  let expected = Try.ok `Need_update in
   let computed = Dummy.handle dummy $ Deps.need_update deps target in
   check
-    (result bool (testable Error.pp Error.equal))
+    (result testable_act (testable Error.pp Error.equal))
     "The target has dependencies but some are out of date, so it should not \
      be updated"
     expected

--- a/tests/dummy.ml
+++ b/tests/dummy.ml
@@ -147,6 +147,9 @@ let handle dummy program =
           let f : type b. (b -> 'a) -> b Effect.f -> 'a =
            fun resume -> function
             | File_exists path -> resume $ file_exists dummy path
+            | Target_exists path -> resume $ file_exists dummy path
+            | Target_modification_time path ->
+              resume $ perform_if_exists path (get_file_mtime dummy)
             | Get_modification_time path ->
               resume $ perform_if_exists path (get_file_mtime dummy)
             | Read_file path ->

--- a/tests/dummy.ml
+++ b/tests/dummy.ml
@@ -110,7 +110,10 @@ let get_file_mtime dummy = Filesystem.get_file_mtime dummy.filesystem
 let get_file_content dummy = Filesystem.get_file_content dummy.filesystem
 
 let content_changes dummy content file =
-  get_file_content dummy file |> Option.map (String.equal content)
+  Try.ok
+    (match get_file_content dummy file with
+    | Some x -> not (String.equal content x)
+    | None -> true)
 ;;
 
 let put dummy message =
@@ -158,7 +161,7 @@ let handle dummy program =
               resume $ perform_if_exists path (get_file_mtime dummy)
             | Content_changes (path, content) ->
               let result =
-                perform_if_exists path (content_changes dummy content)
+                content_changes dummy content path
                 |> Try.Functor.map (function
                        | true -> Either.left content
                        | false -> Either.right ())

--- a/tests/dummy.ml
+++ b/tests/dummy.ml
@@ -109,6 +109,10 @@ let directory_exists dummy = Filesystem.directory_exists dummy.filesystem
 let get_file_mtime dummy = Filesystem.get_file_mtime dummy.filesystem
 let get_file_content dummy = Filesystem.get_file_content dummy.filesystem
 
+let content_changes dummy content file =
+  get_file_content dummy file |> Option.map (String.equal content)
+;;
+
 let put dummy message =
   let new_stdout = Stdout.put dummy.stdout message in
   dummy.stdout <- new_stdout
@@ -152,6 +156,14 @@ let handle dummy program =
               resume $ perform_if_exists path (get_file_mtime dummy)
             | Get_modification_time path ->
               resume $ perform_if_exists path (get_file_mtime dummy)
+            | Content_changes (path, content) ->
+              let result =
+                perform_if_exists path (content_changes dummy content)
+                |> Try.Functor.map (function
+                       | true -> Either.left content
+                       | false -> Either.right ())
+              in
+              resume result
             | Read_file path ->
               resume $ perform_if_exists path (get_file_content dummy)
             | Write_file (path, content) ->

--- a/yocaml_irmin.opam
+++ b/yocaml_irmin.opam
@@ -1,0 +1,36 @@
+opam-version: "2.0"
+version: "dev"
+synopsis: "YOCaml Runtime using Irmin as target"
+maintainer: "xhtmlboi@gmail.com"
+authors: [
+  "The XHTMLBoy <xhtmlboi@gmail.com>"
+  "Xavier Van de Woestyne <xaviervdw@gmail.com>"
+]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name ] {with-test}
+  [ "dune" "build" "@doc" "-p" name ] {with-doc}
+]
+
+license: "GPL-3.0-or-later"
+tags: [ "shell" "bin" "make" "static" "blog" "generator" ]
+homepage: "https://github.com/xhtmlboi/yocaml"
+dev-repo: "git://github.com/xhtmlboi/yocaml.git"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+
+depends: [
+  "ocaml" { >= "4.11.1" }
+  "dune" { >= "2.8" }
+  "odoc" {with-doc}
+  "preface" { >= "0.1.0" }
+  "lwt" { >= "5.4.2" }
+  "irmin" { >= "2.7.2" }
+  "irmin-unix" { >= "2.7.2" }
+  "yocaml" {pinned}
+]
+
+pin-depends: [
+  ["yocaml.dev" "git://github.com/xhtmlboi/yocaml.git"]
+]

--- a/yocaml_unix.opam
+++ b/yocaml_unix.opam
@@ -25,6 +25,7 @@ depends: [
   "dune" { >= "2.8" }
   "odoc" {with-doc}
   "preface" { >= "0.1.0" }
+  "cryptokit" { >= "1.16.1" }
   "yocaml" {pinned}
 ]
 


### PR DESCRIPTION
cc @dinosaure

I suggest you review Commit By Commit.
This PR introduces the possibility of constructing a RUNTIME that distinguishes between a source (ie: Unix) and a target which is an Irmin store. I have added an example. The compilation process works quite well even if sometimes there are false negatives. For example if a file has been modified but the content is the same, Yocaml will indicate that it had to rebuild the file whereas Git didn't patch anything (logical, Yocaml only relies on the date to know if a file needs to be patched, Git uses the content of the file to be patched) however, I don't think this is dramatic at all. 