### PR TITLE
Upgrade yocaml_irmin to irmin.3.2.0

### DIFF
--- a/lib/yocaml_irmin/runtime.ml
+++ b/lib/yocaml_irmin/runtime.ml
@@ -25,9 +25,9 @@ let path_of = String.split_on_char '/'
 module Make
     (Source : Yocaml.Runtime.RUNTIME)
     (Store : Irmin.S
-               with type branch = string
-                and type key = string list
-                and type contents = string)
+        with type Schema.Branch.t = string
+         and type Schema.Path.t = string list
+         and type Schema.Contents.t = string)
     (Lwt_main : LWT_RUN)
     (Config : CONFIG) =
 struct
@@ -65,8 +65,8 @@ struct
   let write_file filepath content =
     let date = Int64.of_float $ Source.get_time () in
     let info () =
-      Irmin.Info.v ~date ~author:commit_author
-      $ Format.asprintf "create file [%s]" filepath
+      Store.Info.v ~author:commit_author
+        ~message:(Format.asprintf "create file [%s]" filepath) date
     in
     let path = path_of filepath in
     let task =
@@ -88,7 +88,7 @@ struct
       | [] -> Ok 0
       | commit :: _ ->
         let info = Store.Commit.info commit in
-        let date = Irmin.Info.date info in
+        let date = Store.Info.date info in
         Ok (Int64.to_int date)
     in
     Lwt_main.run task

--- a/lib/yocaml_irmin/runtime.mli
+++ b/lib/yocaml_irmin/runtime.mli
@@ -12,8 +12,8 @@ end
 module Make
     (Source : Yocaml.Runtime.RUNTIME)
     (Store : Irmin.S
-               with type branch = string
-                and type key = string list
-                and type contents = string)
+        with type Schema.Branch.t = string
+         and type Schema.Path.t = string list
+         and type Schema.Contents.t = string)
     (Lwt_main : LWT_RUN)
     (Config : CONFIG) : Yocaml.Runtime.RUNTIME

--- a/lib/yocaml_irmin/yocaml_irmin.ml
+++ b/lib/yocaml_irmin/yocaml_irmin.ml
@@ -1,9 +1,9 @@
 let execute
     (module Source : Yocaml.Runtime.RUNTIME)
     (module Store : Irmin.S
-      with type branch = string
-       and type key = string list
-       and type contents = string)
+        with type Schema.Branch.t = string
+         and type Schema.Path.t = string list
+         and type Schema.Contents.t = string)
     (module Lwt_main : Runtime.LWT_RUN)
     ?branch
     ?author

--- a/lib/yocaml_irmin/yocaml_irmin.mli
+++ b/lib/yocaml_irmin/yocaml_irmin.mli
@@ -8,9 +8,9 @@
 val execute
   :  (module Yocaml.Runtime.RUNTIME)
   -> (module Irmin.S
-        with type branch = string
-         and type key = string list
-         and type contents = string)
+        with type Schema.Branch.t = string
+         and type Schema.Path.t = string list
+         and type Schema.Contents.t = string)
   -> (module Runtime.LWT_RUN)
   -> ?branch:string
   -> ?author:string

--- a/yocaml_irmin.opam
+++ b/yocaml_irmin.opam
@@ -26,8 +26,8 @@ depends: [
   "odoc" {with-doc}
   "preface" { >= "0.1.0" }
   "lwt" { >= "5.4.2" }
-  "irmin" { >= "2.7.2" }
-  "irmin-unix" { >= "2.7.2" }
+  "irmin" { >= "3.2.0" }
+  "irmin-unix" { >= "3.2.0" }
   "yocaml" {pinned}
 ]
 


### PR DESCRIPTION
A simple upgrade to `irmin.3.2.0`, examples still works :+1:.