### PR TITLE
Free runtime

### DIFF
--- a/examples/06_first_blog_using_jingoo_and_git/bin/my_site.ml
+++ b/examples/06_first_blog_using_jingoo_and_git/bin/my_site.ml
@@ -109,9 +109,9 @@ let () =
   Yocaml_irmin.execute
     (module Yocaml_unix)
     (module Store)
-    (module Lwt_main)
     ~author:"xvw"
     ~author_email:"xaviervdw@gmail.com"
     config
     (pages >> css >> images >> articles >> index)
+  |> Lwt_main.run
 ;;

--- a/lib/yocaml/runtime.ml
+++ b/lib/yocaml/runtime.ml
@@ -1,84 +1,100 @@
 open Util
 
 module type RUNTIME = sig
-  val get_time : unit -> float
-  val file_exists : Filepath.t -> bool
-  val target_exists : Filepath.t -> bool
-  val is_directory : Filepath.t -> bool
-  val get_modification_time : Filepath.t -> int Try.t
-  val target_modification_time : Filepath.t -> int Try.t
-  val read_file : Filepath.t -> string Try.t
-  val content_changes : Filepath.t -> string -> bool Try.t
-  val write_file : Filepath.t -> string -> unit Try.t
-  val read_dir : Filepath.t -> Filepath.t list
-  val create_dir : ?file_perm:int -> Filepath.t -> unit
-  val log : Log.level -> string -> unit
+  type 'a t
+
+  val bind : 'a t -> ('a -> 'b t) -> 'b t
+  val return : 'a -> 'a t
+  val get_time : unit -> float t
+  val file_exists : Filepath.t -> bool t
+  val target_exists : Filepath.t -> bool t
+  val is_directory : Filepath.t -> bool t
+  val get_modification_time : Filepath.t -> int Try.t t
+  val target_modification_time : Filepath.t -> int Try.t t
+  val read_file : Filepath.t -> string Try.t t
+  val content_changes : Filepath.t -> string -> bool Try.t t
+  val write_file : Filepath.t -> string -> unit Try.t t
+  val read_dir : Filepath.t -> Filepath.t list t
+  val create_dir : ?file_perm:int -> Filepath.t -> unit t
+  val log : Log.level -> string -> unit t
 end
 
-let create_predicate (module R : RUNTIME) path pred = function
-  | `Files ->
-    fun x ->
-      let p = x |> into path in
-      if R.file_exists p && not $ R.is_directory p && pred x
-      then Some p
-      else None
-  | `Directories ->
-    fun x ->
-      let p = x |> into path in
-      if R.file_exists p && not $ R.is_directory p && pred x
-      then Some p
-      else None
-  | `Both ->
-    fun x ->
-      let p = x |> into path in
-      if pred x then Some p else None
-;;
+module Make (R : RUNTIME) = struct
+  let ( let* ) = R.bind
 
-let execute (module R : RUNTIME) program =
-  Effect.run
-    { handler =
-        (fun resume effect ->
-          let f : type b. (b -> 'a) -> b Effect.f -> 'a =
-           fun resume -> function
-            | Effect.Get_modification_time path ->
-              resume $ R.get_modification_time path
-            | Effect.Target_modification_time path ->
-              resume $ R.target_modification_time path
-            | Effect.File_exists path -> resume $ R.file_exists path
-            | Effect.Target_exists path -> resume $ R.target_exists path
-            | Effect.Read_file path -> resume $ R.read_file path
-            | Effect.Content_changes (path, content) ->
-              let result =
-                R.content_changes path content
-                |> Try.Functor.map (function
-                       | true -> Either.left content
-                       | false -> Either.right ())
-              in
-              resume result
-            | Effect.Write_file (path, content) ->
-              let () = R.create_dir $ Filename.dirname path in
-              resume $ R.write_file path content
-            | Effect.Read_dir (path, kind, predicate) ->
-              let children = R.read_dir path in
-              let full_predicate =
-                create_predicate (module R) path predicate kind
-              in
-              resume $ List.filter_map full_predicate children
-            | Effect.Log (level, message) ->
-              let () = R.log level message in
-              resume ()
-            | Effect.Throw error ->
-              let () =
-                R.log Log.Alert (Lexicon.crap_there_is_an_error error)
-              in
-              Error.raise' error
-            | Effect.Raise exn ->
-              let () =
-                R.log Log.Alert (Lexicon.crap_there_is_an_exception exn)
-              in
-              raise exn
-          in
-          f resume effect)
-    }
-    program
-;;
+  let create_predicate path pred = function
+    | `Files ->
+      fun x ->
+        let p = x |> into path in
+        let* file_exists = R.file_exists p in
+        let* is_directory = R.is_directory p in
+        if file_exists && (not is_directory) && pred x
+        then R.return (Some p)
+        else R.return None
+    | `Directories ->
+      fun x ->
+        let p = x |> into path in
+        let* file_exists = R.file_exists p in
+        let* is_directory = R.is_directory p in
+        if file_exists && (not is_directory) && pred x
+        then R.return (Some p)
+        else R.return None
+    | `Both ->
+      fun x ->
+        let p = x |> into path in
+        if pred x then R.return (Some p) else R.return None
+  ;;
+
+  let filter_map f l =
+    let rec go acc = function
+      | [] -> R.return (List.rev acc)
+      | hd :: tl ->
+        let* hd = f hd in
+        (match hd with
+        | Some v -> (go [@tailcall]) (v :: acc) tl
+        | None -> (go [@tailcall]) acc tl)
+    in
+    go [] l
+  ;;
+
+  let execute program =
+    let perform : type a. a Effect.f -> a R.t = function
+      | Effect.Get_modification_time path -> R.get_modification_time path
+      | Effect.File_exists path -> R.file_exists path
+      | Effect.Target_modification_time path ->
+        R.target_modification_time path
+      | Effect.Target_exists path -> R.target_exists path
+      | Effect.Read_file path -> R.read_file path
+      | Effect.Content_changes (path, content) ->
+        let* v = R.content_changes path content in
+        R.return
+          (Try.Functor.map
+             (function
+               | true -> Either.left content
+               | false -> Either.right ())
+             v)
+      | Effect.Write_file (path, content) ->
+        let* () = R.create_dir $ Filename.dirname path in
+        R.write_file path content
+      | Effect.Read_dir (path, kind, predicate) ->
+        let* children = R.read_dir path in
+        filter_map (create_predicate path predicate kind) children
+      | Effect.Log (level, message) -> R.log level message
+      | Effect.Throw error ->
+        let* () = R.log Log.Alert (Lexicon.crap_there_is_an_error error) in
+        Error.raise' error
+      | Effect.Raise exn ->
+        let* () = R.log Log.Alert (Lexicon.crap_there_is_an_exception exn) in
+        raise exn
+    in
+    let handler : type b. (b R.t -> 'a R.t) -> b Effect.f -> 'a R.t =
+     fun resume effect -> resume $ (perform effect)
+    in
+    let handler : type b. (b -> 'a R.t) -> b Effect.f -> 'a R.t =
+     fun resume effect ->
+      let resume v = R.bind v (fun v -> resume v) in
+      handler resume effect
+    in
+    Effect.run { handler } (Effect.map R.return program)
+  ;;
+end

--- a/lib/yocaml/runtime.mli
+++ b/lib/yocaml/runtime.mli
@@ -17,55 +17,62 @@
     an additional runtime. *)
 
 module type RUNTIME = sig
+  type 'a t
+
+  val bind : 'a t -> ('a -> 'b t) -> 'b t
+  val return : 'a -> 'a t
+
   (** [get_time ()] should returns a float like [Unix.gettimeofday ()]. *)
-  val get_time : unit -> float
+  val get_time : unit -> float t
 
   (** [file_exists path] should returns [true] if [path] exists (as a file or
       a directory), [false] otherwise. *)
-  val file_exists : Filepath.t -> bool
+  val file_exists : Filepath.t -> bool t
 
   (** Same of [file_exists] but acting on the target. *)
-  val target_exists : Filepath.t -> bool
+  val target_exists : Filepath.t -> bool t
 
   (** [is_directory path] should returns [true] if [path] is an existing file
       and if the file is a directory, [false] otherwise. *)
-  val is_directory : Filepath.t -> bool
+  val is_directory : Filepath.t -> bool t
 
   (** [get_modification_time path] should returns a [Try.t] containing the
       modification time (as an integer) of the given file. The function may
       fail. *)
-  val get_modification_time : Filepath.t -> int Try.t
+  val get_modification_time : Filepath.t -> int Try.t t
 
   (** Same of [get_modification_time] but acting on the target. *)
-  val target_modification_time : Filepath.t -> int Try.t
+  val target_modification_time : Filepath.t -> int Try.t t
 
   (** [read_file path] should returns a [Try.t] containing the content (as a
       string) of the given file. The function may fail.*)
-  val read_file : Filepath.t -> string Try.t
+  val read_file : Filepath.t -> string Try.t t
 
   (** [content_changes filepath new_content] check if the content of the file
       has been changed. *)
-  val content_changes : Filepath.t -> string -> bool Try.t
+  val content_changes : Filepath.t -> string -> bool Try.t t
 
   (** [write_file path content] should write (create or overwrite) [content]
       into the given path. The function may fail. *)
-  val write_file : Filepath.t -> string -> unit Try.t
+  val write_file : Filepath.t -> string -> unit Try.t t
 
   (** [read_dir path] should returns a list of children. The function is
       pretty optimistic if the directory does not exist, or for any other
       possible reason the function should fail, it will return an empty list. *)
-  val read_dir : Filepath.t -> Filepath.t list
+  val read_dir : Filepath.t -> Filepath.t list t
 
   (** [create_dir path] is an optimistic version of [mkdir -p], the function
       extract the directory of a file and create it if it does not exists
       without any failure. *)
-  val create_dir : ?file_perm:int -> Filepath.t -> unit
+  val create_dir : ?file_perm:int -> Filepath.t -> unit t
 
   (** [log level message] justs dump a message on stdout. *)
-  val log : Log.level -> string -> unit
+  val log : Log.level -> string -> unit t
 end
 
 (** {1 Helpers} *)
 
-(** Runs a YOCaml program with a specific runtime. *)
-val execute : (module RUNTIME) -> 'a Effect.t -> 'a
+module Make (R : RUNTIME) : sig
+  (** Runs a YOCaml program with a specific runtime. *)
+  val execute : 'a Effect.t -> 'a R.t
+end

--- a/lib/yocaml_irmin/runtime.mli
+++ b/lib/yocaml_irmin/runtime.mli
@@ -5,15 +5,12 @@ module type CONFIG = sig
   val author_email : string option
 end
 
-module type LWT_RUN = sig
-  val run : 'a Lwt.t -> 'a
-end
+module type RUNTIME = Yocaml.Runtime.RUNTIME with type 'a t = 'a
 
 module Make
-    (Source : Yocaml.Runtime.RUNTIME)
+    (Source : RUNTIME)
     (Store : Irmin.S
                with type Schema.Branch.t = string
                 and type Schema.Path.t = string list
                 and type Schema.Contents.t = string)
-    (Lwt_main : LWT_RUN)
-    (Config : CONFIG) : Yocaml.Runtime.RUNTIME
+    (Config : CONFIG) : Yocaml.Runtime.RUNTIME with type 'a t = 'a Lwt.t

--- a/lib/yocaml_irmin/yocaml_irmin.ml
+++ b/lib/yocaml_irmin/yocaml_irmin.ml
@@ -1,18 +1,17 @@
 let execute
-    (module Source : Yocaml.Runtime.RUNTIME)
+    (module Source : Runtime.RUNTIME)
     (module Store : Irmin.S
       with type Schema.Branch.t = string
        and type Schema.Path.t = string list
        and type Schema.Contents.t = string)
-    (module Lwt_main : Runtime.LWT_RUN)
     ?branch
     ?author
     ?author_email
     config
     program
   =
-  let module R =
-    Runtime.Make (Source) (Store) (Lwt_main)
+  let module R0 =
+    Runtime.Make (Source) (Store)
       (struct
         let config = config
         let branch = Option.value ~default:"master" branch
@@ -20,5 +19,6 @@ let execute
         let author_email = author_email
       end)
   in
-  Yocaml.Runtime.execute (module R) program
+  let module R1 = Yocaml.Runtime.Make (R0) in
+  R1.execute program
 ;;

--- a/lib/yocaml_irmin/yocaml_irmin.mli
+++ b/lib/yocaml_irmin/yocaml_irmin.mli
@@ -6,15 +6,14 @@
 (** Executes a YOCaml program using a given Runtime for processing with
     [Source] and using an [Irmin Store] as compilation target. *)
 val execute
-  :  (module Yocaml.Runtime.RUNTIME)
+  :  (module Runtime.RUNTIME)
   -> (module Irmin.S
         with type Schema.Branch.t = string
          and type Schema.Path.t = string list
          and type Schema.Contents.t = string)
-  -> (module Runtime.LWT_RUN)
   -> ?branch:string
   -> ?author:string
   -> ?author_email:string
   -> Irmin.config
   -> 'a Yocaml.Effect.t
-  -> 'a
+  -> 'a Lwt.t

--- a/lib/yocaml_unix/runtime.ml
+++ b/lib/yocaml_unix/runtime.ml
@@ -1,5 +1,9 @@
 open Yocaml.Util
 
+type 'a t = 'a
+
+let bind x f = f x
+let return x = x
 let get_time () = Unix.gettimeofday ()
 let file_exists = Sys.file_exists
 let is_directory = Sys.is_directory

--- a/lib/yocaml_unix/runtime.mli
+++ b/lib/yocaml_unix/runtime.mli
@@ -1,1 +1,1 @@
-include Yocaml.Runtime.RUNTIME
+include Yocaml.Runtime.RUNTIME with type 'a t = 'a

--- a/lib/yocaml_unix/server.ml
+++ b/lib/yocaml_unix/server.ml
@@ -56,16 +56,14 @@ let handle_404 rootpath =
 ;;
 
 let server filepath port task =
+  let module R = Yocaml.Runtime.Make (Runtime) in
   let handler _conn request _body =
     let uri = request |> Request.uri in
     let path = Path.resolve_local_file ~docroot:filepath ~uri in
     let open Lwt.Syntax in
     let* strategy = define_strategy path in
     match strategy with
-    | File x ->
-      handle_file
-        (fun () -> Lwt.return (Yocaml.Runtime.execute (module Runtime) task))
-        x
+    | File x -> handle_file (fun () -> Lwt.return (R.execute task)) x
     | _ -> handle_404 filepath
   in
   Server.create ~mode:(`TCP (`Port port)) (Server.make ~callback:handler ())

--- a/lib/yocaml_unix/yocaml_unix.ml
+++ b/lib/yocaml_unix/yocaml_unix.ml
@@ -1,4 +1,6 @@
-let execute program = Yocaml.Runtime.execute (module Runtime) program
+module R = Yocaml.Runtime.Make (Runtime)
+
+let execute program = R.execute program
 
 let serve ~filepath ~port task =
   Logs.info (fun pp ->

--- a/lib/yocaml_unix/yocaml_unix.mli
+++ b/lib/yocaml_unix/yocaml_unix.mli
@@ -19,4 +19,4 @@ val serve : filepath:string -> port:int -> unit Yocaml.t -> unit Lwt.t
     Inclusion of the runtime to be able to use [Yocaml_unix] as runtime
     directly. *)
 
-include Yocaml.Runtime.RUNTIME (** @closed *)
+include Yocaml.Runtime.RUNTIME with type 'a t = 'a (** @closed *)


### PR DESCRIPTION
I really try to avoid the usage of a functor but the OCaml type system is not smart enough to be able to write something like:
```ocaml
let op (type 'a m) (module M : MonadSig with 'a t = 'a m) ... : 'a m =
```

So only sane way is to use a _functor_. I tried to use the trick about higher-kinded polymorphism but the codebase became unreadable an unmaintainable. So, the `Yocaml.Runtime.execute` is not available anymore and you must apply the _functor_ `Yocaml.Runtime.Make` to be able to execute your effect:
```ocaml
let server filepath port task =
  let module R = Yocaml.Runtime.Make (Runtime) in
  let handler _conn request _body =
    let uri = request |> Request.uri in
    let path = Path.resolve_local_file ~docroot:filepath ~uri in
    let open Lwt.Syntax in
    let* strategy = define_strategy path in
    match strategy with
    | File x -> handle_file (fun () -> Lwt.return (R.execute task)) x
    | _ -> handle_404 filepath
  in
  Server.create ~mode:(`TCP (`Port port)) (Server.make ~callback:handler ())
```

/cc @xvw: I don't think that an improvement on `preface` will really help, we still have the limitation that `execute` should return an `'a Monad.t`/`'a Lwt.t` and OCaml does not allow that.

This is a draft and if you think that it's the right way, I can clean up the PR.