### PR TITLE
Lint dev-repo metadata into OPAM files

### DIFF
--- a/yocaml.opam
+++ b/yocaml.opam
@@ -14,7 +14,7 @@ build: [
 license: "GPL-3.0-or-later"
 tags: [ "shell" "bin" "make" "static" "blog" "generator" ]
 homepage: "https://github.com/xhtmlboi/yocaml"
-dev-repo: "git://github.com/xhtmlboi/yocaml.git"
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
 bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
     
 depends: [

--- a/yocaml_irmin.opam
+++ b/yocaml_irmin.opam
@@ -17,7 +17,7 @@ build: [
 license: "GPL-3.0-or-later"
 tags: [ "shell" "bin" "make" "static" "blog" "generator" ]
 homepage: "https://github.com/xhtmlboi/yocaml"
-dev-repo: "git://github.com/xhtmlboi/yocaml.git"
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
 bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
 
 depends: [
@@ -32,5 +32,5 @@ depends: [
 ]
 
 pin-depends: [
-  ["yocaml.dev" "git://github.com/xhtmlboi/yocaml.git"]
+  ["yocaml.dev" "git+https://github.com/xhtmlboi/yocaml.git"]
 ]

--- a/yocaml_jingoo.opam
+++ b/yocaml_jingoo.opam
@@ -17,7 +17,7 @@ build: [
 license: "GPL-3.0-or-later"
 tags: [ "shell" "bin" "make" "static" "blog" "generator" ]
 homepage: "https://github.com/xhtmlboi/yocaml"
-dev-repo: "git://github.com/xhtmlboi/yocaml.git"
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
 bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
 
 depends: [
@@ -30,5 +30,5 @@ depends: [
 ]
 
 pin-depends: [
-  ["yocaml.dev" "git://github.com/xhtmlboi/yocaml.git"]
+  ["yocaml.dev" "git+https://github.com/xhtmlboi/yocaml.git"]
 ]

--- a/yocaml_markdown.opam
+++ b/yocaml_markdown.opam
@@ -17,7 +17,7 @@ build: [
 license: "GPL-3.0-or-later"
 tags: [ "shell" "bin" "make" "static" "blog" "generator" ]
 homepage: "https://github.com/xhtmlboi/yocaml"
-dev-repo: "git://github.com/xhtmlboi/yocaml.git"
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
 bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
 
 depends: [
@@ -30,5 +30,5 @@ depends: [
 ]
 
 pin-depends: [
-  ["yocaml.dev" "git://github.com/xhtmlboi/yocaml.git"]
+  ["yocaml.dev" "git+https://github.com/xhtmlboi/yocaml.git"]
 ]

--- a/yocaml_mustache.opam
+++ b/yocaml_mustache.opam
@@ -17,7 +17,7 @@ build: [
 license: "GPL-3.0-or-later"
 tags: [ "shell" "bin" "make" "static" "blog" "generator" ]
 homepage: "https://github.com/xhtmlboi/yocaml"
-dev-repo: "git://github.com/xhtmlboi/yocaml.git"
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
 bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
 
 depends: [
@@ -30,5 +30,5 @@ depends: [
 ]
 
 pin-depends: [
-  ["yocaml.dev" "git://github.com/xhtmlboi/yocaml.git"]
+  ["yocaml.dev" "git+https://github.com/xhtmlboi/yocaml.git"]
 ]

--- a/yocaml_unix.opam
+++ b/yocaml_unix.opam
@@ -17,7 +17,7 @@ build: [
 license: "GPL-3.0-or-later"
 tags: [ "shell" "bin" "make" "static" "blog" "generator" ]
 homepage: "https://github.com/xhtmlboi/yocaml"
-dev-repo: "git://github.com/xhtmlboi/yocaml.git"
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
 bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
 
 depends: [
@@ -33,5 +33,5 @@ depends: [
 ]
 
 pin-depends: [
-  ["yocaml.dev" "git://github.com/xhtmlboi/yocaml.git"]
+  ["yocaml.dev" "git+https://github.com/xhtmlboi/yocaml.git"]
 ]

--- a/yocaml_yaml.opam
+++ b/yocaml_yaml.opam
@@ -17,7 +17,7 @@ build: [
 license: "GPL-3.0-or-later"
 tags: [ "shell" "bin" "make" "static" "blog" "generator" ]
 homepage: "https://github.com/xhtmlboi/yocaml"
-dev-repo: "git://github.com/xhtmlboi/yocaml.git"
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
 bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
 
 depends: [
@@ -30,5 +30,5 @@ depends: [
 ]
 
 pin-depends: [
-  ["yocaml.dev" "git://github.com/xhtmlboi/yocaml.git"]
+  ["yocaml.dev" "git+https://github.com/xhtmlboi/yocaml.git"]
 ]


### PR DESCRIPTION
`opam` complains about `git://` URL and GitHub does not allow anymore to use this kind of protocol to clone repositories. This change replace `git://` by `git+https://`. See the last note of this GitHub's article: https://github.blog/2021-09-01-improving-git-protocol-security-github/