### PR TITLE
Use a Store.repo instead of an Irmin.config for yocaml_irmin

### DIFF
--- a/examples/06_first_blog_using_jingoo_and_git/bin/dune
+++ b/examples/06_first_blog_using_jingoo_and_git/bin/dune
@@ -3,6 +3,7 @@
  (promote (until-clean))
  (libraries
   logs
+  mirage-clock-unix
   yocaml
   yocaml_markdown
   yocaml_yaml

--- a/examples/06_first_blog_using_jingoo_and_git/bin/my_site.ml
+++ b/examples/06_first_blog_using_jingoo_and_git/bin/my_site.ml
@@ -106,12 +106,16 @@ let () =
 ;;
 
 let () =
-  Yocaml_irmin.execute
-    (module Yocaml_unix)
-    (module Store)
-    ~author:"xvw"
-    ~author_email:"xaviervdw@gmail.com"
-    config
-    (pages >> css >> images >> articles >> index)
+  let open Lwt.Infix in
+  Store.Repo.v config
+  >>= (fun repo ->
+        Yocaml_irmin.execute
+          (module Yocaml_unix)
+          (module Pclock)
+          (module Store)
+          ~author:"xvw"
+          ~author_email:"xaviervdw@gmail.com"
+          repo
+          (pages >> css >> images >> articles >> index))
   |> Lwt_main.run
 ;;

--- a/lib/yocaml/runtime.ml
+++ b/lib/yocaml/runtime.ml
@@ -88,7 +88,7 @@ module Make (R : RUNTIME) = struct
         raise exn
     in
     let handler : type b. (b R.t -> 'a R.t) -> b Effect.f -> 'a R.t =
-     fun resume effect -> resume $ (perform effect)
+     fun resume effect -> resume $ perform effect
     in
     let handler : type b. (b -> 'a R.t) -> b Effect.f -> 'a R.t =
      fun resume effect ->

--- a/lib/yocaml_irmin/dune
+++ b/lib/yocaml_irmin/dune
@@ -1,7 +1,7 @@
 (library
  (name yocaml_irmin)
  (public_name yocaml_irmin)
- (libraries lwt irmin preface yocaml))
+ (libraries ptime mirage-clock lwt irmin preface yocaml))
 
 (documentation
  (package yocaml_irmin))

--- a/lib/yocaml_irmin/runtime.mli
+++ b/lib/yocaml_irmin/runtime.mli
@@ -1,16 +1,20 @@
 module type CONFIG = sig
-  val config : Irmin.config
+  type repo
+
   val branch : string
   val author : string option
   val author_email : string option
+  val repository : repo
 end
 
 module type RUNTIME = Yocaml.Runtime.RUNTIME with type 'a t = 'a
 
 module Make
     (Source : RUNTIME)
+    (Pclock : Mirage_clock.PCLOCK)
     (Store : Irmin.S
                with type Schema.Branch.t = string
                 and type Schema.Path.t = string list
                 and type Schema.Contents.t = string)
-    (Config : CONFIG) : Yocaml.Runtime.RUNTIME with type 'a t = 'a Lwt.t
+    (Config : CONFIG with type repo = Store.repo) :
+  Yocaml.Runtime.RUNTIME with type 'a t = 'a Lwt.t

--- a/lib/yocaml_irmin/yocaml_irmin.ml
+++ b/lib/yocaml_irmin/yocaml_irmin.ml
@@ -1,22 +1,36 @@
 let execute
-    (module Source : Runtime.RUNTIME)
-    (module Store : Irmin.S
-      with type Schema.Branch.t = string
-       and type Schema.Path.t = string list
-       and type Schema.Contents.t = string)
-    ?branch
-    ?author
-    ?author_email
-    config
-    program
+    : type repo.
+      (module Runtime.RUNTIME)
+      -> (module Mirage_clock.PCLOCK)
+      -> (module Irmin.S
+            with type Schema.Branch.t = string
+             and type Schema.Path.t = string list
+             and type Schema.Contents.t = string
+             and type repo = repo)
+      -> ?branch:string
+      -> ?author:string
+      -> ?author_email:string
+      -> repo
+      -> 'a Yocaml.Effect.t
+      -> 'a Lwt.t
   =
+ fun (module Source)
+     (module Pclock)
+     (module Store)
+     ?branch
+     ?author
+     ?author_email
+     repository
+     program ->
   let module R0 =
-    Runtime.Make (Source) (Store)
+    Runtime.Make (Source) (Pclock) (Store)
       (struct
-        let config = config
+        type nonrec repo = repo
+
         let branch = Option.value ~default:"master" branch
         let author = author
         let author_email = author_email
+        let repository = repository
       end)
   in
   let module R1 = Yocaml.Runtime.Make (R0) in

--- a/lib/yocaml_irmin/yocaml_irmin.mli
+++ b/lib/yocaml_irmin/yocaml_irmin.mli
@@ -7,13 +7,15 @@
     [Source] and using an [Irmin Store] as compilation target. *)
 val execute
   :  (module Runtime.RUNTIME)
+  -> (module Mirage_clock.PCLOCK)
   -> (module Irmin.S
         with type Schema.Branch.t = string
          and type Schema.Path.t = string list
-         and type Schema.Contents.t = string)
+         and type Schema.Contents.t = string
+         and type repo = 'repo)
   -> ?branch:string
   -> ?author:string
   -> ?author_email:string
-  -> Irmin.config
+  -> 'repo
   -> 'a Yocaml.Effect.t
   -> 'a Lwt.t

--- a/yocaml_irmin.opam
+++ b/yocaml_irmin.opam
@@ -28,6 +28,7 @@ depends: [
   "lwt" { >= "5.4.2" }
   "irmin" { >= "3.2.0" }
   "irmin-unix" { >= "3.2.0" }
+  "mirage-clock"
   "yocaml" {pinned}
 ]
 


### PR DESCRIPTION
This is my last requirement for a proper blog which can push into a Git repository (including an upgrade to `git.3.7.0-1` - see ocaml/opam-repository#21129) which extends _devices_ required by `yocaml_irmin` with a `Mirage_clock.PCLOCK` (to get the POSIX time) and use a `Store.repo` instead of an `Irmin.config` - by this way, we are able to pull the repository, fill it via `Yocaml_irmin.execute` and push modification.