### PR TITLE
Update OPAM files

### DIFF
--- a/yocaml_irmin.opam
+++ b/yocaml_irmin.opam
@@ -29,9 +29,5 @@ depends: [
   "irmin" { >= "3.2.0" }
   "irmin-unix" { >= "3.2.0" }
   "mirage-clock"
-  "yocaml" {pinned}
-]
-
-pin-depends: [
-  ["yocaml.dev" "git+https://github.com/xhtmlboi/yocaml.git"]
+  "yocaml" {= version}
 ]

--- a/yocaml_jingoo.opam
+++ b/yocaml_jingoo.opam
@@ -26,9 +26,5 @@ depends: [
   "odoc" {with-doc}
   "preface" { >= "1.0.0"}
   "jingoo" { >= "1.4.3" }
-  "yocaml" {pinned}
-]
-
-pin-depends: [
-  ["yocaml.dev" "git+https://github.com/xhtmlboi/yocaml.git"]
+  "yocaml" {= version}
 ]

--- a/yocaml_markdown.opam
+++ b/yocaml_markdown.opam
@@ -26,9 +26,5 @@ depends: [
   "odoc" {with-doc}
   "preface" { >= "1.0.0" }
   "omd" { >= "1.3.1" }
-  "yocaml" {pinned}
-]
-
-pin-depends: [
-  ["yocaml.dev" "git+https://github.com/xhtmlboi/yocaml.git"]
+  "yocaml" {= version}
 ]

--- a/yocaml_mustache.opam
+++ b/yocaml_mustache.opam
@@ -26,9 +26,5 @@ depends: [
   "odoc" {with-doc}
   "preface" { >= "1.0.0" }
   "mustache" { >= "3.1.0" }
-  "yocaml" {pinned}
-]
-
-pin-depends: [
-  ["yocaml.dev" "git+https://github.com/xhtmlboi/yocaml.git"]
+  "yocaml" {= version}
 ]

--- a/yocaml_unix.opam
+++ b/yocaml_unix.opam
@@ -27,11 +27,7 @@ depends: [
   "preface" { >= "1.0.0" }
   "cryptokit" { >= "1.16.1" }
   "logs" {>= "0.7.0" }
-  "conduit-lwt" { >= "4.0.0" }
-  "cohttp-lwt-unix" { >= "4.0.0" }
-  "yocaml" {pinned}
-]
-
-pin-depends: [
-  ["yocaml.dev" "git+https://github.com/xhtmlboi/yocaml.git"]
+  "paf" {>= "0.3.0"}
+  "tcpip"
+  "yocaml" {= version}
 ]

--- a/yocaml_yaml.opam
+++ b/yocaml_yaml.opam
@@ -26,9 +26,5 @@ depends: [
   "odoc" {with-doc}
   "preface" { >= "1.0.0" }
   "yaml" { >= "2.1.0" }
-  "yocaml" {pinned}
-]
-
-pin-depends: [
-  ["yocaml.dev" "git+https://github.com/xhtmlboi/yocaml.git"]
+  "yocaml" {= version}
 ]


### PR DESCRIPTION
Use `{= version}` instead of pin-depends. The disadvantage of `pin-depends` is the transitivity. Indeed, a package which wants to depend to `yocaml` and plugins must add the `pin-depends` too. This new layout of OPAM packages is mainly used when a "distribution" (mainly, a GitHub repository) provides several packages. To ensure the publication of all of them with right constraints (because `pin-depends` is not allowed into `ocaml/opam-repository`), you can see that many packages (such as Irmin or Git) use this layout.