### PR TITLE
Fix the target_exists function which can return [Ok false]

### DIFF
--- a/lib/yocaml_git/runtime.ml
+++ b/lib/yocaml_git/runtime.ml
@@ -36,7 +36,7 @@ struct
     let open Lwt.Infix in
     Store.exists Config.store path
     >|= function
-    | Ok _ -> true
+    | Ok v -> Option.is_some v
     | Error _ -> false
   ;;
 


### PR DESCRIPTION
I did a minor mistake about `target_exists` which leads to a wrong behavior when we want to push a new file into the Git repository.