### PR TITLE
Add Heyplzlookatme's Gemini capsule link in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,4 @@ And in the `dune` file of your executable:
 | [xvw.capsule](https://xvw.github.io/capsule/)                                | [@xvw](https://github.com/xvw)                             | [Github](https://github.com/xvw/capsule)                          |
 | [Oxywa](https://hakimba.github.io/oxywa/)                                    | [@hakimba](https://github.com/Hakimba)                     | [Github](https://github.com/Hakimba/oxywa)                        |
 | [Guillaume Petiot](https://guillaumepetiot.com/)                             | [@gpetiot](https://github.com/gpetiot/)                    | [Github](https://github.com/gpetiot/blogger)                      |
-
-
+| [gemini://heyplzlookat.me/](gemini://heyplzlookat.me/)                       | [@Psi-prod](https://github.com/Psi-Prod/)                  | [Github](https://github.com/Psi-Prod/Capsule)                     |


### PR DESCRIPTION
However I don't believe that GitHub renders clickable links with a protocol other than http.