### PR TITLE
A first draft of an Atom syndication format plugin.

### DIFF
--- a/lib/yocaml/rss.ml
+++ b/lib/yocaml/rss.ml
@@ -465,18 +465,14 @@ module Channel = struct
     =
     Format.fprintf
       ppf
-      "<?xml version=\"%s\" encoding=\"%s\" ?><rss version=\"2.0\" \
+      "<?xml version=%S encoding=%S ?><rss version=\"2.0\" \
        xmlns:atom=\"http://www.w3.org/2005/Atom\">%a</rss>"
       xml_version
       encoding
       (pp ~default_time)
   ;;
 
-  let to_rss
-    ?(xml_version = "1.0")
-    ?(encoding = "UTF-8")
-    ?(default_time = 10, 0, 0)
-    =
-    Format.asprintf "%a" $ pp_rss ~xml_version ~encoding ~default_time
+  let to_rss ?xml_version ?encoding ?(default_time = 10, 0, 0) =
+    Format.asprintf "%a" $ pp_rss ?xml_version ?encoding ~default_time
   ;;
 end

--- a/lib/yocaml_syndication/dune
+++ b/lib/yocaml_syndication/dune
@@ -1,7 +1,7 @@
 (library
  (name yocaml_syndication)
  (public_name yocaml_syndication)
- (libraries yocaml syndic preface))
+ (libraries yocaml syndic preface ptime))
 
 (documentation
  (package yocaml_syndication))

--- a/lib/yocaml_syndication/dune
+++ b/lib/yocaml_syndication/dune
@@ -1,0 +1,7 @@
+(library
+ (name yocaml_syndication)
+ (public_name yocaml_syndication)
+ (libraries yocaml syndic preface))
+
+(documentation
+ (package yocaml_syndication))

--- a/lib/yocaml_syndication/yocaml_syndication.ml
+++ b/lib/yocaml_syndication/yocaml_syndication.ml
@@ -53,4 +53,25 @@ module Atom = struct
   let to_atom ?xml_version ?encoding feed =
     Format.asprintf "%a" (pp_atom ?xml_version ?encoding) feed
   ;;
+
+  let entry_of_article url authors article =
+    let module Article = Yocaml.Metadata.Article in
+    let (year, month, day), time =
+      Article.date article |> Yocaml.Date.to_pair
+    in
+    let time = Option.value time ~default:(0, 0, 0) in
+    match
+      Ptime.of_date_time
+        ((year, Yocaml.Date.month_to_int month, day), (time, 0))
+    with
+    | None -> failwith "article date is not representable!"
+    | Some updated ->
+      Syndic.Atom.entry
+        ~id:url
+        ~title:(Text (Article.article_title article))
+        ~authors
+        ~updated
+        ~summary:(Text (Article.article_description article))
+        ()
+  ;;
 end

--- a/lib/yocaml_syndication/yocaml_syndication.ml
+++ b/lib/yocaml_syndication/yocaml_syndication.ml
@@ -1,0 +1,29 @@
+module Atom = struct
+  type t = Syndic.Atom.feed
+
+  let make =
+    Syndic.Atom.feed
+      ~generator:
+        { version = Some "dev"
+        ; uri = Some (Uri.of_string "https://github.com/xhtmlboi/yocaml")
+        ; content = "YOcaml"
+        }
+  ;;
+
+  let pp ppf feed =
+    Format.fprintf ppf "%s" (Syndic.Atom.to_xml feed |> Syndic.XML.to_string)
+  ;;
+
+  let pp_atom ?(xml_version = "1.0") ?(encoding = "UTF-8") ppf feed =
+    Format.fprintf
+      ppf
+      "<?xml version=%S encoding=%S?>%s"
+      xml_version
+      encoding
+      (Syndic.Atom.to_xml feed |> Syndic.XML.to_string)
+  ;;
+
+  let to_atom ?xml_version ?encoding feed =
+    Format.asprintf "%a" (pp_atom ?xml_version ?encoding) feed
+  ;;
+end

--- a/lib/yocaml_syndication/yocaml_syndication.ml
+++ b/lib/yocaml_syndication/yocaml_syndication.ml
@@ -1,13 +1,40 @@
 module Atom = struct
   type t = Syndic.Atom.feed
 
-  let make =
+  let default_generator =
+    { Syndic.Atom.version = Some "dev"
+    ; uri = Some (Uri.of_string "https://github.com/xhtmlboi/yocaml")
+    ; content = "YOcaml"
+    }
+  ;;
+
+  let make
+    ?authors
+    ?categories
+    ?contributors
+    ?(generator = default_generator)
+    ?icon
+    ?links
+    ?logo
+    ?rights
+    ?subtitle
+    ~id
+    ~title
+    ~updated
+    =
     Syndic.Atom.feed
-      ~generator:
-        { version = Some "dev"
-        ; uri = Some (Uri.of_string "https://github.com/xhtmlboi/yocaml")
-        ; content = "YOcaml"
-        }
+      ?authors
+      ?categories
+      ?contributors
+      ?icon
+      ~generator
+      ?links
+      ?logo
+      ?rights
+      ?subtitle
+      ~id
+      ~title
+      ~updated
   ;;
 
   let pp ppf feed =

--- a/lib/yocaml_syndication/yocaml_syndication.mli
+++ b/lib/yocaml_syndication/yocaml_syndication.mli
@@ -1,0 +1,33 @@
+(** An Atom representation. *)
+
+(** {1 Describe an Atom feed} *)
+
+module Atom : sig
+  type t = Syndic.Atom.feed
+
+  val make
+    :  ?authors:Syndic.Atom.author list
+    -> ?categories:Syndic.Atom.category list
+    -> ?contributors:Syndic.Atom.author list
+    -> ?icon:Uri.t
+    -> ?links:Syndic.Atom.link list
+    -> ?logo:Uri.t
+    -> ?rights:Syndic.Atom.text_construct
+    -> ?subtitle:Syndic.Atom.text_construct
+    -> id:Uri.t
+    -> title:Syndic.Atom.text_construct
+    -> updated:Syndic.Date.t
+    -> Syndic.Atom.entry list
+    -> t
+
+  val pp : Format.formatter -> t -> unit
+
+  val pp_atom
+    :  ?xml_version:string
+    -> ?encoding:string
+    -> Format.formatter
+    -> t
+    -> unit
+
+  val to_atom : ?xml_version:string -> ?encoding:string -> t -> string
+end

--- a/lib/yocaml_syndication/yocaml_syndication.mli
+++ b/lib/yocaml_syndication/yocaml_syndication.mli
@@ -9,6 +9,7 @@ module Atom : sig
     :  ?authors:Syndic.Atom.author list
     -> ?categories:Syndic.Atom.category list
     -> ?contributors:Syndic.Atom.author list
+    -> ?generator:Syndic.Atom.generator
     -> ?icon:Uri.t
     -> ?links:Syndic.Atom.link list
     -> ?logo:Uri.t

--- a/lib/yocaml_syndication/yocaml_syndication.mli
+++ b/lib/yocaml_syndication/yocaml_syndication.mli
@@ -31,5 +31,10 @@ module Atom : sig
     -> unit
 
   val to_atom : ?xml_version:string -> ?encoding:string -> t -> string
-  val entry_of_article : Yocaml.Metadata.Article.t -> Syndic.Atom.entry
+
+  val entry_of_article
+    :  Uri.t
+    -> Syndic.Atom.author * Syndic.Atom.author list
+    -> Yocaml.Metadata.Article.t
+    -> Syndic.Atom.entry
 end

--- a/lib/yocaml_syndication/yocaml_syndication.mli
+++ b/lib/yocaml_syndication/yocaml_syndication.mli
@@ -3,6 +3,8 @@
 (** {1 Describe an Atom feed} *)
 
 module Atom : sig
+  (** See http://cumulus.github.io/Syndic/syndic/Syndic__/Syndic_atom/index.html. *)
+
   type t = Syndic.Atom.feed
 
   val make

--- a/lib/yocaml_syndication/yocaml_syndication.mli
+++ b/lib/yocaml_syndication/yocaml_syndication.mli
@@ -31,4 +31,5 @@ module Atom : sig
     -> unit
 
   val to_atom : ?xml_version:string -> ?encoding:string -> t -> string
+  val entry_of_article : Yocaml.Metadata.Article.t -> Syndic.Atom.entry
 end

--- a/yocaml_syndication.opam
+++ b/yocaml_syndication.opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+version: "dev"
+synopsis: "YOCaml Syndication"
+maintainer: "xhtmlboi@gmail.com"
+authors: [
+  "The XHTMLBoy <xhtmlboi@gmail.com>"
+  "Xavier Van de Woestyne <xaviervdw@gmail.com>"
+]
+
+build: [
+  [ "dune" "subst" ] {dev}
+  [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name ] {with-test}
+  [ "dune" "build" "@doc" "-p" name ] {with-doc}
+]
+
+license: "GPL-3.0-or-later"
+tags: [ "shell" "bin" "make" "static" "blog" "generator" ]
+homepage: "https://github.com/xhtmlboi/yocaml"
+dev-repo: "git+https://github.com/xhtmlboi/yocaml.git"
+bug-reports: "https://github.com/xhtmlboi/yocaml/issues"
+
+depends: [
+  "ocaml" { >= "4.11.1" }
+  "dune" { >= "2.8" }
+  "odoc" {with-doc}
+  "syndic" { >= "1.6.1"}
+  "yocaml" {= version}
+]


### PR DESCRIPTION
We discussed it [here](https://github.com/xhtmlboi/yocaml/issues/42
) so here is a first try with several weaknesses:
* I tried as much as possible to have an API similar to `Yocaml.Rss` but I didn't know if it was wise that the parameters that are URLs should be `Uri.t` or more naturally `string`.

* In `Atom.make`, the data used to create `generator` parameter are hardcoded, they could be replaced by generating the yocaml `.opam` file [with dune](https://dune.readthedocs.io/en/stable/opam.html) and using watermarks [replaced by dune](https://dune.readthedocs.io/en/stable/usage.html#dune-subst).

* I don't know if the data such as `authors` must also be wrapped in their own data type to erase `syndic` traces

In addition, I fixed a small detail `Format.printf "\"%s\"" str` can be replaced by `Format.printf "%S" str`.