### PR TITLE
Fix XML namespacing in Yocaml_syndication.

### DIFF
--- a/lib/yocaml_syndication/yocaml_syndication.ml
+++ b/lib/yocaml_syndication/yocaml_syndication.ml
@@ -47,7 +47,10 @@ module Atom = struct
       "<?xml version=%S encoding=%S?>%s"
       xml_version
       encoding
-      (Syndic.Atom.to_xml feed |> Syndic.XML.to_string)
+      (Syndic.Atom.to_xml feed
+      |> Syndic.XML.to_string ~ns_prefix:(function
+           | "http://www.w3.org/2005/Atom" -> Some ""
+           | _ -> Some "http://www.w3.org/2005/Atom"))
   ;;
 
   let to_atom ?xml_version ?encoding feed =


### PR DESCRIPTION
Fix a little mistake of mine before it does any more damage in the future. Now I'm not the only one using the plugin 😛
