### PR TITLE
Yocaml_git: Allow specifying a commit message

### DIFF
--- a/lib/yocaml_git/yocaml_git.ml
+++ b/lib/yocaml_git/yocaml_git.ml
@@ -1,13 +1,13 @@
 let execute
   :  (module Runtime.RUNTIME) -> (module Mirage_clock.PCLOCK) -> ctx:Mimic.ctx
-  -> ?author:string -> ?email:string -> string -> 'a Yocaml.Effect.t
+  -> ?author:string -> ?email:string -> ?comment:string -> string -> 'a Yocaml.Effect.t
   -> ('a, [> `Msg of string ]) result Lwt.t
   =
- fun (module Source) (module Pclock) ~ctx ?author ?email remote program ->
+ fun (module Source) (module Pclock) ~ctx ?author ?email ?comment remote program ->
   let open Lwt.Syntax in
   let* store = Git_kv.connect ctx remote in
   let module Store = Git_kv.Make (Pclock) in
-  Store.change_and_push ?author ?author_email:email store
+  Store.change_and_push ?author ?author_email:email ?message:comment store
   @@ fun store ->
   let module R0 =
     Runtime.Make (Source) (Pclock)

--- a/lib/yocaml_git/yocaml_git.mli
+++ b/lib/yocaml_git/yocaml_git.mli
@@ -16,6 +16,7 @@ val execute
   -> ctx:Mimic.ctx
   -> ?author:string
   -> ?email:string
+  -> ?comment:string
   -> string
   -> 'a Yocaml.Effect.t
   -> ('a, [> `Msg of string ]) result Lwt.t


### PR DESCRIPTION
I thought it could be useful to log the git hash the content was generated from, and with this option it is possible to set the commit message.