### PR TITLE
mdx is required for non-test as well

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -24,7 +24,7 @@
    (qcheck :with-test)
    (qcheck-alcotest :with-test)
    ppx_expect
-   (mdx (and :with-test (= 2.5.0)))
+   (mdx (= 2.5.0))
    (ocamlformat :with-dev-setup)
    (ocp-indent :with-dev-setup)
    (merlin :with-dev-setup)

--- a/yocaml.opam
+++ b/yocaml.opam
@@ -18,7 +18,7 @@ depends: [
   "qcheck" {with-test}
   "qcheck-alcotest" {with-test}
   "ppx_expect"
-  "mdx" {with-test & = "2.5.0"}
+  "mdx" {= "2.5.0"}
   "ocamlformat" {with-dev-setup}
   "ocp-indent" {with-dev-setup}
   "merlin" {with-dev-setup}


### PR DESCRIPTION
Maybe this is not intentional, but none the less it's the case. Alternatively, the `mdx` stanza in `lib/core/dune` should be declared for the test target. I don't remember how to do that off the top of my head.