### PR TITLE
Update to git-kv.0.1.2 and workaround git-kv bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### Next
+
+- Update to git-kv 1.0.2 and work around last modified behavior inside a `Git_kv.change_and_push` call (by [reynir](https://reyn.ir))
+
+
 ### v2.1.0 2024-12-14 Nantes (France)
 
 - Support for OCaml `5.3.0` (by [kit-ty-kate](https://github.com/kit-ty-kate))

--- a/dune-project
+++ b/dune-project
@@ -152,7 +152,7 @@
    (lwt (>= 5.7.0))
    (mimic (>= 0.0.9))
    (cstruct (>= 6.2.0))
-   (git-kv (>= 0.0.5))
+   (git-kv (>= 0.1.2))
    (git-unix (>= 3.16.1))
    (mirage-clock (>= 4.2.0))
    (yocaml (= :version))

--- a/plugins/yocaml_git/yocaml_git.ml
+++ b/plugins/yocaml_git/yocaml_git.ml
@@ -26,6 +26,19 @@ let run (module Source : Required.SOURCE) (module Clock : Mirage_clock.PCLOCK)
   let* context = match context with `SSH -> Ssh.context () in
   let* store = Git_kv.connect context remote in
   let module Store = Git_kv.Make (Clock) in
+  let module Store = struct
+    include Store
+    (* last_modified and change_and_push have a weird interaction;
+       so we show the old last_modified *)
+    let last_modified new_store key =
+      let* r = last_modified store key in
+      match r with
+      | Error `Not_found _ ->
+        last_modified new_store key
+      | _ ->
+        Lwt.return r
+  end
+  in
   Store.change_and_push ?author ?author_email:email ?message store (fun store ->
       let module Config = struct
         let store = store

--- a/yocaml_git.opam
+++ b/yocaml_git.opam
@@ -16,7 +16,7 @@ depends: [
   "lwt" {>= "5.7.0"}
   "mimic" {>= "0.0.9"}
   "cstruct" {>= "6.2.0"}
-  "git-kv" {>= "0.0.5"}
+  "git-kv" {>= "0.1.2"}
   "git-unix" {>= "3.16.1"}
   "mirage-clock" {>= "4.2.0"}
   "yocaml" {= version}


### PR DESCRIPTION
Git-kv 0.1.1 has a bug in its last_modified implementation, and the current semantics has an odd interaction with change_and_push that we need to work around.

See #61 