### PR TITLE
Add a new `Yocaml_is_file` effect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Add a Applicative Helpers for Archetypes (by [gr-im](https://github.com/gr-im)
 - Improve `Archetype.Articles.fetch` (by [xhtmlboi](https://github.com/xhtmlboi))
 - Add `Pipeline.fetch` and `Pipeline.fetch_some` (by [gr-im](https://github.com/gr-im)
+- Add a new effect to define if a Path is a file (in order to disambiguate file and path for `Yocaml_git`) (by [xvw](https://xvw.lol))
 
 #### Yocaml_jingoo
 
@@ -17,6 +18,19 @@
 
 - Add `read_template` to have a better fit with Applicative API (by [gr-im](https://github.com/gr-im)
 - Add `read_templates` to have a better fit with Applicative API when chaining templates (by [gr-im](https://github.com/gr-im)
+
+#### Yocaml_unix
+
+- Adapt runtime to `is_file` (by [xvw](https://xvw.lol))
+
+#### Yocaml_eio
+
+- Adapt runtime to `is_file` (by [xvw](https://xvw.lol))
+
+#### Yocaml_git
+
+- Adapt runtime to `is_file` (by [xvw](https://xvw.lol))
+
 
 ### v2.4.1 2025-09-01 Nantes (France)
 

--- a/lib/core/eff.ml
+++ b/lib/core/eff.ml
@@ -110,6 +110,7 @@ type _ Effect.t +=
   | Yocaml_hash_content : string -> string Effect.t
   | Yocaml_write_file : filesystem * Path.t * string -> unit Effect.t
   | Yocaml_is_directory : filesystem * Path.t -> bool Effect.t
+  | Yocaml_is_file : filesystem * Path.t -> bool Effect.t
   | Yocaml_read_dir : filesystem * Path.t -> Path.fragment list Effect.t
   | Yocaml_create_dir : filesystem * Path.t -> unit Effect.t
   | Yocaml_exec_command :
@@ -142,6 +143,7 @@ let logf ?src ?(level = `Debug) =
   Format.kasprintf (fun result -> log ?src ~level result)
 
 let is_directory ~on path = perform @@ Yocaml_is_directory (on, path)
+let is_file ~on path = perform @@ Yocaml_is_file (on, path)
 
 let exec ?(is_success = Int.equal 0) exec_name ?(args = []) =
   perform @@ Yocaml_exec_command (exec_name, args, is_success)
@@ -149,13 +151,6 @@ let exec ?(is_success = Int.equal 0) exec_name ?(args = []) =
 let exec_cmd ?is_success cmd =
   let command, args = Cmd.normalize cmd in
   exec ?is_success ~args command
-
-let is_file ~on path =
-  let* file_exists = file_exists ~on path in
-  if file_exists then
-    let+ is_dir = is_directory ~on path in
-    not is_dir
-  else return false
 
 let ensure_file_exists ~on f path =
   let* exists = file_exists ~on path in

--- a/lib/core/eff.mli
+++ b/lib/core/eff.mli
@@ -259,7 +259,9 @@ type _ Effect.t +=
   | Yocaml_write_file : filesystem * Path.t * string -> unit Effect.t
         (** Effect which describes the writing of a file *)
   | Yocaml_is_directory : filesystem * Path.t -> bool Effect.t
-        (** Effect that returns check if a file is a directory or not. *)
+        (** Effect that returns check if a path is a directory or not. *)
+  | Yocaml_is_file : filesystem * Path.t -> bool Effect.t
+        (** Effect that returns check if a path is a file. *)
   | Yocaml_read_dir : filesystem * Path.t -> Path.fragment list Effect.t
         (** Effect that returns a list of names of files (and directory) present
             in the given directory. (Names should be not prefixed by the given

--- a/lib/core/required.mli
+++ b/lib/core/required.mli
@@ -225,6 +225,10 @@ module type RUNTIME = sig
   (** [is_directory ~on:source path] returns [true] if the given path is a
       directory, [false] otherwise. *)
 
+  val is_file : on:[ `Source | `Target ] -> Path.t -> bool t
+  (** [is_file ~on:source path] returns [true] if the given path is a file,
+      [false] otherwise. *)
+
   val read_dir :
        on:[ `Source | `Target ]
     -> Path.t

--- a/lib/core/runtime.ml
+++ b/lib/core/runtime.ml
@@ -112,6 +112,11 @@ module Make (Runtime : Required.RUNTIME) = struct
                     (fun (k : (a, _) continuation) ->
                       Runtime.bind (continue k)
                         (Runtime.is_directory ~on:filesystem path))
+              | Eff.Yocaml_is_file (filesystem, path) ->
+                  Some
+                    (fun (k : (a, _) continuation) ->
+                      Runtime.bind (continue k)
+                        (Runtime.is_file ~on:filesystem path))
               | Eff.Yocaml_read_dir (filesystem, path) ->
                   Some
                     (fun (k : (a, _) continuation) ->

--- a/plugins/yocaml_eio/runtime.ml
+++ b/plugins/yocaml_eio/runtime.ml
@@ -50,6 +50,10 @@ let is_directory ~on:_ path env =
   let path = to_eio_path env path in
   Eio.Path.is_directory path
 
+let is_file ~on:_ path env =
+  let path = to_eio_path env path in
+  Eio.Path.is_file path
+
 let create_directory ~on:_ path env =
   try
     let path = to_eio_path env path in

--- a/plugins/yocaml_git/runtime.ml
+++ b/plugins/yocaml_git/runtime.ml
@@ -105,6 +105,11 @@ struct
       | `Source -> Source.lift @@ Source.is_directory ~on path
       | `Target -> Lwt.return true
 
+    let is_file ~on path =
+      match on with
+      | `Source -> Source.lift @@ Source.is_file ~on path
+      | `Target -> Lwt.return true
+
     let exec ?is_success prog args =
       lift_result @@ Source.exec ?is_success prog args
 

--- a/plugins/yocaml_unix/runtime.ml
+++ b/plugins/yocaml_unix/runtime.ml
@@ -34,6 +34,8 @@ let is_directory ~on:_ path =
   let path = Yocaml.Path.to_string path in
   try Sys.is_directory path with _ -> false
 
+let is_file ~on path = file_exists ~on path && not (is_directory ~on path)
+
 let create_directory ~on:_ path =
   try
     let path = Yocaml.Path.to_string path in

--- a/test/e2e/bin/gen.ml
+++ b/test/e2e/bin/gen.ml
@@ -118,8 +118,11 @@ let program (resolver : resolver) () =
   >>= articles_aux_2 resolver
   >>= Yocaml.Action.store_cache ~on:`Target resolver#cache
 
+module R = Yocaml.Runtime.Make (Runtime)
+
 let () =
   let () = Array.iter print_endline Sys.argv in
   let cwd = Yocaml.Path.rel [] in
   let resolver = new resolver ~source:cwd ~target:cwd in
-  Yocaml_unix.run ~level:`Debug (program resolver)
+  let () = Yocaml_runtime.Log.setup ~level:`Debug () in
+  R.run (program resolver)

--- a/test/e2e/bin/runtime.ml
+++ b/test/e2e/bin/runtime.ml
@@ -1,0 +1,4 @@
+include Yocaml_unix.Runtime
+
+let read_dir ~on path =
+  path |> read_dir ~on |> Result.map (List.sort String.compare)

--- a/test/e2e/bin/runtime.mli
+++ b/test/e2e/bin/runtime.mli
@@ -1,0 +1,1 @@
+include Yocaml.Required.RUNTIME with type 'a t = 'a

--- a/test/e2e/run.t
+++ b/test/e2e/run.t
@@ -5,28 +5,28 @@ Run the generator
   [DEBUG]Cache initiated in `./_www/.cache`
   [DEBUG]`./_www/style.css` will be written
   [INFO]`./_www/style.css` has been written
-  [DEBUG]`./_www/articles/second_article.html` will be written
-  [INFO]`./_www/articles/second_article.html` has been written
-  [DEBUG]./content/templates/article.html already stored
-  [DEBUG]./content/templates/layout.html already stored
   [DEBUG]`./_www/articles/first_article.html` will be written
   [INFO]`./_www/articles/first_article.html` has been written
   [DEBUG]./content/templates/article.html already stored
   [DEBUG]./content/templates/layout.html already stored
-  [DEBUG]`./_www/articles-with-applicative-read/second_article.html` will be written
-  [INFO]`./_www/articles-with-applicative-read/second_article.html` has been written
+  [DEBUG]`./_www/articles/second_article.html` will be written
+  [INFO]`./_www/articles/second_article.html` has been written
   [DEBUG]./content/templates/article.html already stored
   [DEBUG]./content/templates/layout.html already stored
   [DEBUG]`./_www/articles-with-applicative-read/first_article.html` will be written
   [INFO]`./_www/articles-with-applicative-read/first_article.html` has been written
   [DEBUG]./content/templates/article.html already stored
   [DEBUG]./content/templates/layout.html already stored
-  [DEBUG]`./_www/articles-with-applicative-read-2/second_article.html` will be written
-  [INFO]`./_www/articles-with-applicative-read-2/second_article.html` has been written
+  [DEBUG]`./_www/articles-with-applicative-read/second_article.html` will be written
+  [INFO]`./_www/articles-with-applicative-read/second_article.html` has been written
   [DEBUG]./content/templates/article.html already stored
   [DEBUG]./content/templates/layout.html already stored
   [DEBUG]`./_www/articles-with-applicative-read-2/first_article.html` will be written
   [INFO]`./_www/articles-with-applicative-read-2/first_article.html` has been written
+  [DEBUG]./content/templates/article.html already stored
+  [DEBUG]./content/templates/layout.html already stored
+  [DEBUG]`./_www/articles-with-applicative-read-2/second_article.html` will be written
+  [INFO]`./_www/articles-with-applicative-read-2/second_article.html` has been written
   [DEBUG]Cache stored in `./_www/.cache`
 
 Inspect tree

--- a/test/lib/fs.ml
+++ b/test/lib/fs.ml
@@ -198,6 +198,10 @@ let push_is_directory trace on path =
   push_trace trace
   @@ Format.asprintf "[IS_DIRECTORY][%a]%a" on_pp on Yocaml.Path.pp path
 
+let push_is_file trace on path =
+  push_trace trace
+  @@ Format.asprintf "[IS_FILE][%a]%a" on_pp on Yocaml.Path.pp path
+
 let push_read_directory trace on path =
   push_trace trace
   @@ Format.asprintf "[READ_DIRECTORY][%a]%a" on_pp on Yocaml.Path.pp path
@@ -364,6 +368,19 @@ let run ~trace program input =
                       | _ -> false
                       (* We suppose that if a file does not exists,
                          it is not a directory... *)
+                    in
+                    continue k res)
+            | Yocaml_is_file (on, gpath) ->
+                Some
+                  (fun (k : (a, _) continuation) ->
+                    let () = trace := push_is_file !trace on gpath in
+                    let path = Yocaml.Path.to_list gpath in
+                    let res =
+                      match get !trace.system path with
+                      | Some (File _) -> true
+                      | _ -> false
+                      (* We suppose that if a file does not exists,
+                         it is not a file... *)
                     in
                     continue k res)
             | Yocaml_read_dir (on, gpath) ->


### PR DESCRIPTION
An improvement of #81 (and should fix #80). 

The idea is to introduce a new effect `Yocaml_is_file` that always return `true` for `Yocaml_git`.
cc @dinosaure 

(And on the last commit, I try to make e2e test more consistent)