### PR TITLE
Remove use of executables_implicit_empty_intf

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,6 @@
 (name yocaml)
 (version dev)
 (generate_opam_files true)
-(executables_implicit_empty_intf)
 (using mdx 0.4)
 (maintenance_intent "(latest)")
 


### PR DESCRIPTION
> This option is enabled by default starting with Dune lang 3.0.

https://dune.readthedocs.io/en/latest/reference/dune-project/executables_implicit_empty_intf.html