### PR TITLE
Use the upstream version of httpcats

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -65,7 +65,7 @@
    (ocaml (>= 5.1.1))
    ppx_expect
    (mdx (and :with-test (>= 2.5.0)))
-   (httpcats (>= 0.0.1))
+   (httpcats (>= 0.3.0))
    (yocaml (= :version))
    (yocaml_runtime (= :version))))
 

--- a/plugins/yocaml_unix/server.ml
+++ b/plugins/yocaml_unix/server.ml
@@ -80,7 +80,7 @@ let dir reqd path lpath =
     in
     render_html reqd (Yocaml_runtime.Server.Pages.directory lpath children)
 
-let[@warning "-8"] handler htdoc refresh _socket
+let[@warning "-8"] handler htdoc refresh _socket _conn
     (`V1 reqd : Httpcats.Server.reqd) =
   try
     refresh ();
@@ -106,4 +106,4 @@ let run ?custom_error_handler directory port program =
   let sockaddr = Unix.(ADDR_INET (inet_addr_loopback, port)) in
   Miou_unix.run ~domains:0 @@ fun () ->
   Yocaml_runtime.Server.prompt port;
-  Httpcats.Server.clear ~handler sockaddr
+  Httpcats.Server.clear ~handler (Httpcats.Server.Bind sockaddr)

--- a/yocaml_unix.opam
+++ b/yocaml_unix.opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "5.1.1"}
   "ppx_expect"
   "mdx" {with-test & >= "2.5.0"}
-  "httpcats" {>= "0.0.1"}
+  "httpcats" {>= "0.3.0"}
   "yocaml" {= version}
   "yocaml_runtime" {= version}
   "odoc" {with-doc}


### PR DESCRIPTION
I will make a release (v0.3.0) today. This is a patch to use the latest version.